### PR TITLE
feat: add flash messages to base layout

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -105,6 +105,21 @@
 
         <!-- Main content -->
         <main class="flex-1 p-8 overflow-auto">
+            {% set flashTypes = ['success', 'warning', 'danger', 'info'] %}
+            {% set flashClasses = {
+                'success': 'border-green-400 bg-green-100 text-green-700',
+                'warning': 'border-yellow-400 bg-yellow-100 text-yellow-700',
+                'danger':  'border-red-400 bg-red-100 text-red-700',
+                'info':    'border-blue-400 bg-blue-100 text-blue-700'
+            } %}
+
+            {% for type in flashTypes %}
+                {% for message in app.flashes(type) %}
+                    <div class="mb-4 border-l-4 p-4 {{ flashClasses[type] }}" role="alert">
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            {% endfor %}
 
             {% block body %}{% endblock %}
         </main>


### PR DESCRIPTION
## Summary
- display Twig flash messages for success, warning, danger and info in the base layout

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*


------
https://chatgpt.com/codex/tasks/task_e_688da5c23da48323a80692bf89e34481