### PR TITLE
feat: allow closing flash messages

### DIFF
--- a/site/assets/controllers/flash_controller.js
+++ b/site/assets/controllers/flash_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    close() {
+        this.element.remove();
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -115,8 +115,9 @@
 
             {% for type in flashTypes %}
                 {% for message in app.flashes(type) %}
-                    <div class="mb-4 border-l-4 p-4 {{ flashClasses[type] }}" role="alert">
-                        {{ message }}
+                    <div data-controller="flash" class="mb-4 border-l-4 p-4 {{ flashClasses[type] }} flex items-center justify-between" role="alert">
+                        <span>{{ message }}</span>
+                        <button type="button" class="ml-4 text-xl leading-none" data-action="flash#close">&times;</button>
                     </div>
                 {% endfor %}
             {% endfor %}


### PR DESCRIPTION
## Summary
- allow flash messages to be dismissed
- add Stimulus controller to remove messages on demand

## Testing
- `npm run build`
- `php -d memory_limit=-1 vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_688da7bd39b0832388833100e76a0d5c