### PR TITLE
Enable closing flash messages

### DIFF
--- a/site/assets/bootstrap.js
+++ b/site/assets/bootstrap.js
@@ -1,6 +1,8 @@
 // import { startStimulusApp } from '@symfony/stimulus-bundle';
 import { startStimulusApp } from '@symfony/stimulus-bridge';
+import FlashController from './controllers/flash_controller.js';
 
 const app = startStimulusApp();
+app.register('flash', FlashController);
 // register any custom, 3rd party controllers here
 // app.register('some_controller_name', SomeImportedController);


### PR DESCRIPTION
## Summary
- register the flash Stimulus controller so messages can be dismissed

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688daa8910208323a071ce6d38b2b288