### PR TITLE
Handle errors and flash messages when creating Telegram bots

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -49,17 +49,23 @@ class TelegramBotController extends AbstractController
             if (!$this->telegramService->validateToken($bot->getToken())) {
                 $this->addFlash('danger', 'Неверный токен Telegram');
             } else {
-                $webhookUrl = $this->generateUrl('telegram.webhook', [
-                    'token' => $bot->getToken(),
-                ], UrlGeneratorInterface::ABSOLUTE_URL);
+                try {
+                    $webhookUrl = $this->generateUrl('telegram.webhook', [
+                        'token' => $bot->getToken(),
+                    ], UrlGeneratorInterface::ABSOLUTE_URL);
 
-                $this->telegramService->setWebhook($bot->getToken(), $webhookUrl);
-                $bot->setWebhookUrl($webhookUrl);
+                    $this->telegramService->setWebhook($bot->getToken(), $webhookUrl);
+                    $bot->setWebhookUrl($webhookUrl);
 
-                $this->em->persist($bot);
-                $this->em->flush();
+                    $this->em->persist($bot);
+                    $this->em->flush();
 
-                return $this->redirectToRoute('telegram_bot.index');
+                    $this->addFlash('success', 'Бот успешно создан');
+
+                    return $this->redirectToRoute('telegram_bot.index');
+                } catch (\Throwable $e) {
+                    $this->addFlash('danger', 'Ошибка при создании бота: ' . $e->getMessage());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- wrap Telegram bot creation in error-handling to surface flash messages
- show success flash message when a bot is created
- show failure flash message on exceptions

## Testing
- `composer lint` *(fails: phplint: not found)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_688dac783b008323ae20f6e0d8ff5e17