### PR TITLE
Allow POST requests for Telegram bot creation

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -36,7 +36,7 @@ class TelegramBotController extends AbstractController
         ]);
     }
 
-    #[Route('/create', name: 'telegram_bot.create')]
+    #[Route('/create', name: 'telegram_bot.create', methods: ['GET', 'POST'])]
     public function create(Request $request): Response
     {
         $company = $this->companyContext->getCompany();


### PR DESCRIPTION
## Summary
- support POST submissions on Telegram bot create route

## Testing
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_688daf51c5f88323a3a3fb71514716be