### PR TITLE
Fix Telegram bot creation route

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Form\FormError;
 
-#[Route('telegram/bots')]
+#[Route('/telegram/bots')]
 class TelegramBotController extends AbstractController
 {
     public function __construct(


### PR DESCRIPTION
## Summary
- ensure Telegram bot routes use absolute prefix to handle form submissions

## Testing
- `php -l src/Controller/TelegramBotController.php`
- `composer install --no-interaction --no-progress` *(fails: curl error 56 while downloading from api.github.com)*

------
https://chatgpt.com/codex/tasks/task_e_688dc3e4412c8323bbb85ab594411828