### PR TITLE
Add API endpoint for fetching company clients

### DIFF
--- a/site/src/Controller/Api/ClientController.php
+++ b/site/src/Controller/Api/ClientController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Entity\Client;
+use App\Repository\ClientRepository;
+use App\Repository\CompanyRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class ClientController extends AbstractController
+{
+    #[Route('/api/clients', name: 'api.clients', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function index(Request $request, ClientRepository $clients, CompanyRepository $companies): JsonResponse
+    {
+        $activeCompanyId = $request->getSession()->get('active_company_id');
+        if (!$activeCompanyId) {
+            return new JsonResponse(['error' => 'Active company not selected'], Response::HTTP_FORBIDDEN);
+        }
+
+        $company = $companies->find($activeCompanyId);
+        if (!$company) {
+            return new JsonResponse(['error' => 'Active company not found'], Response::HTTP_FORBIDDEN);
+        }
+
+        $items = $clients->findBy(['company' => $company]);
+
+        $data = array_map(static function (Client $client) {
+            return [
+                'id' => $client->getId(),
+                'name' => $client->getUsername(),
+                'channel' => $client->getChannel(),
+                'external_id' => $client->getExternalId(),
+            ];
+        }, $items);
+
+        return new JsonResponse($data);
+    }
+}
+

--- a/site/src/Entity/Client.php
+++ b/site/src/Entity/Client.php
@@ -2,10 +2,11 @@
 
 namespace App\Entity;
 
+use App\Repository\ClientRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Webmozart\Assert\Assert;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: ClientRepository::class)]
 #[ORM\Table(name: '`clients`')]
 class Client
 {

--- a/site/src/Repository/ClientRepository.php
+++ b/site/src/Repository/ClientRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Client;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class ClientRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Client::class);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ClientRepository for database operations
- expose `/api/clients` endpoint returning clients for active company

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer lint` *(fails: phplint: not found)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_688de64610448323a444f31cdb2a36fc