### PR TITLE
Add endpoint to fetch client messages

### DIFF
--- a/site/src/Controller/Api/MessageController.php
+++ b/site/src/Controller/Api/MessageController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Entity\Message;
+use App\Repository\ClientRepository;
+use App\Repository\MessageRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class MessageController extends AbstractController
+{
+    #[Route('/api/messages/{client_id}', name: 'api.messages', methods: ['GET'])]
+    #[IsGranted('ROLE_USER')]
+    public function list(string $client_id, Request $request, ClientRepository $clients, MessageRepository $messages): JsonResponse
+    {
+        $activeCompanyId = $request->getSession()->get('active_company_id');
+        if (!$activeCompanyId) {
+            return new JsonResponse(['error' => 'Active company not selected'], Response::HTTP_FORBIDDEN);
+        }
+
+        $client = $clients->find($client_id);
+        if (!$client) {
+            return new JsonResponse(['error' => 'Client not found'], Response::HTTP_NOT_FOUND);
+        }
+
+        if ($client->getCompany()->getId() !== $activeCompanyId) {
+            return new JsonResponse(['error' => 'Access denied'], Response::HTTP_FORBIDDEN);
+        }
+
+        $items = $messages->findBy(['client' => $client], ['createdAt' => 'ASC']);
+        $dataMessages = array_map(static function (Message $message) {
+            return [
+                'id' => $message->getId(),
+                'text' => $message->getText(),
+                'direction' => $message->getDirection() === Message::IN ? 'incoming' : 'outgoing',
+                'timestamp' => $message->getCreatedAt()->format(DATE_ATOM),
+            ];
+        }, $items);
+
+        $data = [
+            'client' => [
+                'id' => $client->getId(),
+                'name' => $client->getUsername(),
+                'channel' => $client->getChannel(),
+                'external_id' => $client->getExternalId(),
+            ],
+            'messages' => $dataMessages,
+        ];
+
+        return new JsonResponse($data);
+    }
+}
+

--- a/site/src/Entity/Message.php
+++ b/site/src/Entity/Message.php
@@ -4,8 +4,9 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Webmozart\Assert\Assert;
+use App\Repository\MessageRepository;
 
-#[ORM\Entity]
+#[ORM\Entity(repositoryClass: MessageRepository::class)]
 #[ORM\Table(name: '`messages`')]
 class Message
 {

--- a/site/src/Repository/MessageRepository.php
+++ b/site/src/Repository/MessageRepository.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Message;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class MessageRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Message::class);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Doctrine repository for Message entity
- expose GET /api/messages/{client_id} to list messages for a client within active company

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_688de9bd656c8323bac829d35e30c4ed