### PR TITLE
Fix chat React component initial rendering with Turbo navigation

### DIFF
--- a/site/assets/chat-center/index.tsx
+++ b/site/assets/chat-center/index.tsx
@@ -3,10 +3,12 @@ import { createRoot } from 'react-dom/client';
 import ChatLayout from './components/ChatLayout';
 import '../styles/app.css'; // Если используете Tailwind
 
-document.addEventListener('DOMContentLoaded', () => {
+const renderChat = () => {
     const rootElement = document.getElementById('chat-center-root');
     if (rootElement) {
         const root = createRoot(rootElement);
         root.render(<ChatLayout />);
     }
-});
+};
+
+document.addEventListener('turbo:load', renderChat);


### PR DESCRIPTION
## Summary
- Mount chat-center React component on `turbo:load` so Turbo Drive pages render correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e3723366c8323aef4c1c75ddc23f5