### PR TITLE
refactor: move telegram send to service

### DIFF
--- a/site/src/Service/TelegramService.php
+++ b/site/src/Service/TelegramService.php
@@ -19,6 +19,14 @@ class TelegramService
         return isset($response['ok']) && true === $response['ok'];
     }
 
+    public function sendMessage(string $token, string $chatId, string $text): void
+    {
+        $this->sendTelegramRequest($token, 'sendMessage', [
+            'chat_id' => $chatId,
+            'text'    => $text,
+        ]);
+    }
+
     private function sendTelegramRequest(string $token, string $method, array $params): array
     {
         $url = "https://api.telegram.org/bot{$token}/{$method}";


### PR DESCRIPTION
## Summary
- delegate Telegram sendMessage logic to TelegramService
- use TelegramService from MessageController

## Testing
- `composer install` *(fails: curl error 56 while downloading from GitHub)*
- `composer test` *(fails: curl error 56 while downloading from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_688e495098dc8323b925c128ac0c644c