### PR TITLE
Fix message send endpoint parsing

### DIFF
--- a/site/src/Controller/Api/MessageController.php
+++ b/site/src/Controller/Api/MessageController.php
@@ -92,6 +92,11 @@ class MessageController extends AbstractController
         }
 
         $data = json_decode($request->getContent(), true);
+
+        if (!is_array($data)) {
+            $data = $request->request->all();
+        }
+
         $text = $data['text'] ?? null;
 
         $errors = $validator->validate($text, [new Assert\NotBlank(), new Assert\Length(max: 1000)]);


### PR DESCRIPTION
## Summary
- handle form-encoded request bodies in message send endpoint

## Testing
- `composer test` *(fails: phpunit: not found)*
- `composer install` *(fails: curl error 56 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c3bfe8083239a45b9afc6299cc3