### PR TITLE
Add Telegram bot deletion endpoint

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -120,5 +120,26 @@ class TelegramBotController extends AbstractController
             ]);
         }*/
 
-    // + edit() и delete() при необходимости
+    #[Route('/{id}/delete', name: 'telegram_bot.delete', methods: ['POST'])]
+    public function delete(TelegramBot $bot, Request $request): Response
+    {
+        if ($bot->getCompany() !== $this->companyContext->getCompany()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if ($this->isCsrfTokenValid('delete_bot_'.$bot->getId(), $request->request->get('_token'))) {
+            try {
+                $this->telegramService->deleteWebhook($bot->getToken());
+            } catch (\Throwable $e) {
+                // Игнорируем ошибки удаления вебхука
+            }
+
+            $this->em->remove($bot);
+            $this->em->flush();
+
+            $this->addFlash('success', 'Бот удалён');
+        }
+
+        return $this->redirectToRoute('telegram_bot.index');
+    }
 }

--- a/site/src/Service/TelegramService.php
+++ b/site/src/Service/TelegramService.php
@@ -19,6 +19,13 @@ class TelegramService
         return isset($response['ok']) && true === $response['ok'];
     }
 
+    public function deleteWebhook(string $token): bool
+    {
+        $response = $this->sendTelegramRequest($token, 'deleteWebhook', []);
+
+        return isset($response['ok']) && true === $response['ok'];
+    }
+
     public function sendMessage(string $token, string $chatId, string $text): void
     {
         $this->sendTelegramRequest($token, 'sendMessage', [

--- a/site/templates/telegram_bot/index.html.twig
+++ b/site/templates/telegram_bot/index.html.twig
@@ -14,6 +14,7 @@
             <th class="px-4 py-2">Token</th>
             <th class="px-4 py-2">Webhook</th>
             <th class="px-4 py-2">Статус</th>
+            <th class="px-4 py-2">Действия</th>
         </tr>
         </thead>
         <tbody>
@@ -22,6 +23,12 @@
                 <td class="px-4 py-2 text-xs">{{ bot.token|slice(0,15) ~ '...' }}</td>
                 <td class="px-4 py-2 text-xs">{{ bot.webhookUrl }}</td>
                 <td class="px-4 py-2">{{ bot.isActive ? '🟢 Активен' : '🔴 Отключён' }}</td>
+                <td class="px-4 py-2">
+                    <form method="post" action="{{ path('telegram_bot.delete', { id: bot.id }) }}" class="inline">
+                        <input type="hidden" name="_token" value="{{ csrf_token('delete_bot_' ~ bot.id) }}">
+                        <button class="text-red-600" onclick="return confirm('Удалить бота?')">Удалить</button>
+                    </form>
+                </td>
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- allow deleting Telegram bots and remove webhook
- add delete button in bots list

## Testing
- `composer lint` *(fails: phplint: not found)*
- `composer test` *(fails: phpunit: not found)*
- `composer install --no-progress --no-interaction` *(fails: unable to clone https://github.com/symfony/flex.git, 403)*

------
https://chatgpt.com/codex/tasks/task_e_6891b02930a083239593e1e4099be51b