### PR TITLE
Separate bot creation from webhook setup

### DIFF
--- a/site/migrations/Version20240816120000.php
+++ b/site/migrations/Version20240816120000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240816120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add username and first_name fields to telegram_bots';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "telegram_bots" ADD username VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE "telegram_bots" ADD first_name VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "telegram_bots" DROP username');
+        $this->addSql('ALTER TABLE "telegram_bots" DROP first_name');
+    }
+}
+

--- a/site/src/Entity/TelegramBot.php
+++ b/site/src/Entity/TelegramBot.php
@@ -18,6 +18,12 @@ class TelegramBot
     private string $token;
 
     #[ORM\Column(length: 255, nullable: true)]
+    private ?string $username = null;
+
+    #[ORM\Column(length: 255, name: 'first_name', nullable: true)]
+    private ?string $firstName = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
     private ?string $webhookUrl = null;
 
     #[ORM\Column]
@@ -45,6 +51,26 @@ class TelegramBot
     public function setToken(string $token): void
     {
         $this->token = $token;
+    }
+
+    public function getUsername(): ?string
+    {
+        return $this->username;
+    }
+
+    public function setUsername(?string $username): void
+    {
+        $this->username = $username;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(?string $firstName): void
+    {
+        $this->firstName = $firstName;
     }
 
     public function getWebhookUrl(): ?string

--- a/site/src/Service/TelegramService.php
+++ b/site/src/Service/TelegramService.php
@@ -8,11 +8,14 @@ use Longman\TelegramBot\Telegram;
 // src/Service/TelegramService.php
 class TelegramService
 {
-    public function validateToken(string $token): bool
+    /**
+     * @return array<string, mixed>
+     */
+    public function validateToken(string $token): array
     {
         $response = $this->sendTelegramRequest($token, 'getMe', []);
 
-        return isset($response['ok']) && true === $response['ok'];
+        return $response['result'];
     }
 
     public function setWebhook(string $token, string $webhookUrl): bool

--- a/site/templates/telegram_bot/index.html.twig
+++ b/site/templates/telegram_bot/index.html.twig
@@ -24,6 +24,7 @@
                 <td class="px-4 py-2 text-xs">{{ bot.webhookUrl }}</td>
                 <td class="px-4 py-2">{{ bot.isActive ? '🟢 Активен' : '🔴 Отключён' }}</td>
                 <td class="px-4 py-2">
+                    <a href="{{ path('telegram_bot.set_webhook', { id: bot.id }) }}" class="text-blue-600 mr-2">Установить Webhook</a>
                     <form method="post" action="{{ path('telegram_bot.delete', { id: bot.id }) }}" class="inline">
                         <input type="hidden" name="_token" value="{{ csrf_token('delete_bot_' ~ bot.id) }}">
                         <button class="text-red-600" onclick="return confirm('Удалить бота?')">Удалить</button>


### PR DESCRIPTION
## Summary
- rename bot creation action and persist bot info (username, first name, token, active flag) without webhook
- add endpoint to set webhook on demand
- store username and first name fields for Telegram bots and expose webhook install link in UI

## Testing
- `composer lint` (failed: phplint not found)
- `composer install` (failed: CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_689437a534ac8323bd27af5e3c68071e