### PR TITLE
feat: add telegram message fetching

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -98,6 +98,23 @@ class TelegramBotController extends AbstractController
         return $this->redirectToRoute('telegram_bot.index');
     }
 
+    #[Route('/{id}/fetch-messages', name: 'telegram_bot.fetch_messages', methods: ['GET'])]
+    public function fetchMessages(TelegramBot $bot): Response
+    {
+        if ($bot->getCompany() !== $this->companyContext->getCompany()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $messages = $this->telegramService->fetchMessages($bot->getToken());
+            $this->addFlash('success', 'Получено сообщений: '.\count($messages));
+        } catch (\Throwable $e) {
+            $this->addFlash('danger', 'Ошибка при получении сообщений: '.$e->getMessage());
+        }
+
+        return $this->redirectToRoute('telegram_bot.index');
+    }
+
     #[Route('/{id}/delete', name: 'telegram_bot.delete', methods: ['POST'])]
     public function delete(TelegramBot $bot, Request $request): Response
     {

--- a/site/templates/telegram_bot/index.html.twig
+++ b/site/templates/telegram_bot/index.html.twig
@@ -25,6 +25,7 @@
                 <td class="px-4 py-2">{{ bot.isActive ? '🟢 Активен' : '🔴 Отключён' }}</td>
                 <td class="px-4 py-2">
                     <a href="{{ path('telegram_bot.set_webhook', { id: bot.id }) }}" class="text-blue-600 mr-2">Установить Webhook</a>
+                    <a href="{{ path('telegram_bot.fetch_messages', { id: bot.id }) }}" class="text-green-600 mr-2">Установить сообщения</a>
                     <form method="post" action="{{ path('telegram_bot.delete', { id: bot.id }) }}" class="inline">
                         <input type="hidden" name="_token" value="{{ csrf_token('delete_bot_' ~ bot.id) }}">
                         <button class="text-red-600" onclick="return confirm('Удалить бота?')">Удалить</button>


### PR DESCRIPTION
## Summary
- add ability to fetch Telegram messages for a bot
- expose button in bot list to trigger message fetch

## Testing
- `composer test` *(fails: phpunit: not found)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68943dbaa0608323862304a2acfa4546