### PR TITLE
Fix migration order for telegram bots table

### DIFF
--- a/site/migrations/Version20250731150000.php
+++ b/site/migrations/Version20250731150000.php
@@ -7,7 +7,7 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version20240816120000 extends AbstractMigration
+final class Version20250731150000 extends AbstractMigration
 {
     public function getDescription(): string
     {


### PR DESCRIPTION
## Summary
- rename telegram_bots migration so it runs after table creation

## Testing
- `php -l migrations/Version20250731150000.php`
- `composer lint` *(fails: phplint: not found)*
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894e836b1208323a434aaa4fbf938f2