### PR TITLE
feat: enable realtime updates in chat center

### DIFF
--- a/site/assets/chat-center/components/MessageList.tsx
+++ b/site/assets/chat-center/components/MessageList.tsx
@@ -1,4 +1,4 @@
-// assets/chat-center/components/MessageList.tsx__
+// assets/chat-center/components/MessageList.tsx
 
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
@@ -12,23 +12,28 @@ type Message = {
 
 type Props = {
     clientId: string;
+    reload: boolean; // 👈 добавили
 };
 
-const MessageList: React.FC<Props> = ({ clientId }) => {
+const MessageList: React.FC<Props> = ({ clientId, reload }) => {
     const [messages, setMessages] = useState<Message[]>([]);
 
     useEffect(() => {
         if (!clientId) return;
-        axios.get(`/api/messages/${clientId}`).then((res) => setMessages(res.data.messages));
-    }, [clientId]);
+        axios.get(`/api/messages/${clientId}`).then((res) => {
+            setMessages(res.data?.messages ?? []);
+        });
+    }, [clientId, reload]); // 👈 обновляем при reload
 
     return (
-        <div className="space-y-2">
+        <div className="flex flex-col space-y-2">
             {messages.map((msg) => (
                 <div
                     key={msg.id}
                     className={`max-w-xs px-4 py-2 rounded-lg ${
-                        msg.direction === 'in' ? 'bg-gray-200 self-start' : 'bg-blue-500 text-white self-end ml-8'
+                        msg.direction === 'in'
+                            ? 'bg-gray-200 self-start ml-2'
+                            : 'bg-blue-500 text-white self-end mr-2'
                     }`}
                 >
                     <div>{msg.text}</div>


### PR DESCRIPTION
## Summary
- hook up chat center to socket.io for realtime message updates
- refetch messages whenever reload flag changes

## Testing
- `npm test` (fails: Missing script: "test")
- `composer test` (fails: phpunit: not found)


------
https://chatgpt.com/codex/tasks/task_e_6897054da41083239bdf9d7a8ddd79a0