### PR TITLE
Configure realtime socket env via docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -113,6 +113,9 @@ services:
             - "3001:3001"
         volumes:
             - ./socket-server:/app
+        environment:
+            PORT: 3001
+            REDIS_URL: redis://redis-realtime:6379
         networks:
             - traefik-public
             - default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,9 @@ services:
             - "3001:3001"
         volumes:
             - ./socket-server:/app
+        environment:
+            PORT: 3001
+            REDIS_URL: redis://redis-realtime:6379
         depends_on:
             - redis-realtime
         networks:

--- a/socket-server/.env
+++ b/socket-server/.env
@@ -1,2 +1,0 @@
-PORT=3001
-REDIS_URL=redis://redis-realtime:6379


### PR DESCRIPTION
## Summary
- supply socket-server PORT and REDIS_URL via docker-compose
- remove redundant socket server .env

## Testing
- `docker compose -f docker-compose.yml config` *(fails: command not found)*
- `yamllint docker-compose.yml docker-compose.prod.yml` *(fails: command not found)*
- `pip install pyyaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689716eda0048323a15a8979ec9d7ca4