### PR TITLE
feat: configure socket url via env

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,8 @@ services:
         build:
             context: site
             dockerfile: docker/production/nginx/Dockerfile
+            args:
+                SOCKET_URL: https://chat.2bstock.ru
         container_name: site-nginx
         restart: always
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,12 +59,16 @@ services:
         working_dir: /app
         command: sh -c "yarn run watch"
         tty: true
-    
+        environment:
+            SOCKET_URL: http://localhost:3001
+
     site-node-cli:
         image: node:18-alpine
         volumes:
             - ./site:/app
         working_dir: /app
+        environment:
+            SOCKET_URL: http://localhost:3001
     
     site-postgres:
         image: postgres:15-alpine

--- a/site/assets/chat-center/hooks/useSocket.ts
+++ b/site/assets/chat-center/hooks/useSocket.ts
@@ -11,12 +11,21 @@ type MessagePayload = {
     timestamp?: string;
 };
 
+// allow using an env variable injected at build time
+declare const process: {
+    env: {
+        SOCKET_URL?: string;
+    };
+};
+
 function getSocketUrl(): string {
-    // можно пробросить через глобал или .env
+    if (typeof process !== 'undefined' && process.env.SOCKET_URL) {
+        return process.env.SOCKET_URL;
+    }
     if (typeof window !== 'undefined' && (window as any).__SOCKET_URL__) {
         return (window as any).__SOCKET_URL__;
     }
-    return 'http://localhost:3001'; // подставь свой публичный адрес/прокси на проде
+    return 'http://localhost:3001';
 }
 
 export function useSocket(

--- a/site/docker/production/nginx/Dockerfile
+++ b/site/docker/production/nginx/Dockerfile
@@ -24,6 +24,9 @@ RUN chown www-data:www-data ./var -R
 #----------------------------------------------------------
 FROM node:18-alpine AS node-builder
 
+ARG SOCKET_URL
+ENV SOCKET_URL=${SOCKET_URL}
+
 WORKDIR /app
 
 COPY ./package.json ./yarn.lock ./

--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -74,6 +74,11 @@ Encore
     // uncomment if you use React
     .enableReactPreset()
 
+    // expose socket url to the frontend build
+    .configureDefinePlugin((options) => {
+        options['process.env.SOCKET_URL'] = JSON.stringify(process.env.SOCKET_URL || '');
+    })
+
     // uncomment to get integrity="..." attributes on your script & link tags
     // requires WebpackEncoreBundle 1.4 or higher
     //.enableIntegrityHashes(Encore.isProduction())


### PR DESCRIPTION
## Summary
- allow specifying SOCKET_URL for chat client via environment
- expose SOCKET_URL through docker-compose and production build

## Testing
- `yarn install` *(fails: RequestError 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68971b5413548323be692d29bea17078