### PR TITLE
fix: allow new Telegram clients to persist

### DIFF
--- a/site/src/Command/TelegramPollUpdatesCommand.php
+++ b/site/src/Command/TelegramPollUpdatesCommand.php
@@ -119,7 +119,7 @@ final class TelegramPollUpdatesCommand extends Command
             if (ctype_digit($chatId)) {
                 $client->setTelegramId((int) $chatId);
             }
-            if (!$client->getTelegramBot()) {
+            if (null === $client->getTelegramBot()) {
                 $client->setTelegramBot($bot);
             }
             if (($chat['first_name'] ?? null) && !$client->getFirstName()) {

--- a/site/src/Entity/Messaging/Client.php
+++ b/site/src/Entity/Messaging/Client.php
@@ -57,7 +57,7 @@ class Client
         $this->company = $company;
     }
 
-    public function getTelegramBot(): TelegramBot
+    public function getTelegramBot(): ?TelegramBot
     {
         return $this->telegramBot;
     }


### PR DESCRIPTION
## Summary
- fix fatal error when checking telegram bot for new clients
- ensure command sets bot only when missing

## Testing
- `composer lint` *(fails: phplint not found)*
- `composer test` *(fails: phpunit not found)*
- `composer install` *(fails: GitHub API 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f4350bd708323a48cdd0bb9f1573f