### PR TITLE
fix: ensure llm logging for telegram events

### DIFF
--- a/site/src/Command/TelegramPollUpdatesCommand.php
+++ b/site/src/Command/TelegramPollUpdatesCommand.php
@@ -146,8 +146,10 @@ final class TelegramPollUpdatesCommand extends Command
                 $intentRes = $this->llm->chat([
                     'model' => 'gpt-4o-mini',
                     'messages' => [['role' => 'user', 'content' => $text]],
-                    'feature' => AiFeature::INTENT_CLASSIFY->value ?? 'intent_classify',
+                    'feature' => AiFeature::INTENT_CLASSIFY->value,
                     'channel' => 'telegram',
+                    // LlmClientWithLogging требует указания компании
+                    'company' => $bot->getCompany(),
                 ]);
 
                 $intent = trim((string) ($intentRes['content'] ?? ''));

--- a/site/src/Controller/Webhook/TelegramWebhookController.php
+++ b/site/src/Controller/Webhook/TelegramWebhookController.php
@@ -115,9 +115,10 @@ class TelegramWebhookController extends AbstractController
                 $res = $llm->chat([
                     'model' => 'gpt-4o-mini',
                     'messages' => [['role' => 'user', 'content' => $text]],
-                    'feature' => AiFeature::INTENT_CLASSIFY,  // <-- важно
-                    'channel' => 'telegram',         // <-- важно
-                    'company' => $bot->getCompany(), // <-- обязательно Company
+                    // LlmClientWithLogging expects feature as string
+                    'feature' => AiFeature::INTENT_CLASSIFY->value,
+                    'channel' => 'telegram',
+                    'company' => $bot->getCompany(),
                 ]);
 
                 /*$res = $llm->chat([


### PR DESCRIPTION
## Summary
- fix Telegram webhook controller to send feature string to LlmClient
- ensure Telegram poll command provides company context for logging

## Testing
- `php -l src/Controller/Webhook/TelegramWebhookController.php`
- `php -l src/Command/TelegramPollUpdatesCommand.php`
- `php bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install --no-interaction` *(fails: curl error 56: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a214e494048323b02d2955a8568077