### PR TITLE
Fix Telegram channel check in MessageController send action

### DIFF
--- a/site/src/Controller/Api/MessageController.php
+++ b/site/src/Controller/Api/MessageController.php
@@ -93,7 +93,7 @@ class MessageController extends AbstractController
             return new JsonResponse(['error' => 'Access denied'], Response::HTTP_FORBIDDEN);
         }
 
-        if (Client::TELEGRAM !== $client->getChannel()) {
+        if (Channel::TELEGRAM !== $client->getChannel()) {
             return new JsonResponse(['error' => 'Client is not from telegram'], Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
## Summary
- use Channel enum for client telegram check to allow outbound messages to be sent

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a598840e088323b3eb7271d2cfbb05