### PR TITLE
Add ability to disable Telegram bot webhook

### DIFF
--- a/site/src/Controller/TelegramBotController.php
+++ b/site/src/Controller/TelegramBotController.php
@@ -100,6 +100,27 @@ class TelegramBotController extends AbstractController
         return $this->redirectToRoute('telegram_bot.index');
     }
 
+    #[Route('/{id}/delete-webhook', name: 'telegram_bot.delete_webhook', methods: ['GET'])]
+    public function deleteWebhook(TelegramBot $bot): Response
+    {
+        if ($bot->getCompany() !== $this->companyContext->getCompany()) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $this->telegramService->deleteWebhook($bot->getToken());
+            $bot->setWebhookUrl(null);
+            $bot->setIsActive(false);
+            $this->em->flush();
+
+            $this->addFlash('success', 'Webhook успешно отключён');
+        } catch (\Throwable $e) {
+            $this->addFlash('danger', 'Ошибка при отключении webhook: '.$e->getMessage());
+        }
+
+        return $this->redirectToRoute('telegram_bot.index');
+    }
+
     #[Route('/{id}/fetch-messages', name: 'telegram_bot.fetch_messages', methods: ['GET'])]
     public function fetchMessages(TelegramBot $bot): Response
     {

--- a/site/templates/telegram_bot/index.html.twig
+++ b/site/templates/telegram_bot/index.html.twig
@@ -25,6 +25,7 @@
                 <td class="px-4 py-2">{{ bot.isActive ? '🟢 Активен' : '🔴 Отключён' }}</td>
                 <td class="px-4 py-2">
                     <a href="{{ path('telegram_bot.set_webhook', { id: bot.id }) }}" class="text-blue-600 mr-2">Установить Webhook</a>
+                    <a href="{{ path('telegram_bot.delete_webhook', { id: bot.id }) }}" class="text-yellow-600 mr-2">Отключить Webhook</a>
                     <a href="{{ path('telegram_bot.fetch_messages', { id: bot.id }) }}" class="text-green-600 mr-2">Установить сообщения</a>
                     <form method="post" action="{{ path('telegram_bot.delete', { id: bot.id }) }}" class="inline">
                         <input type="hidden" name="_token" value="{{ csrf_token('delete_bot_' ~ bot.id) }}">


### PR DESCRIPTION
## Summary
- add controller action to remove Telegram bot webhook and deactivate bot
- expose webhook removal link in Telegram bot list

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f37ddb708323b00e873ff993562f