### PR TITLE
Set ROLE_OWNER on user registration

### DIFF
--- a/site/src/Controller/RegistrationController.php
+++ b/site/src/Controller/RegistrationController.php
@@ -19,6 +19,8 @@ class RegistrationController extends AbstractController
     public function register(Request $request, UserPasswordHasherInterface $userPasswordHasher, Security $security, EntityManagerInterface $entityManager): Response
     {
         $user = new User(id: Uuid::uuid4()->toString());
+        // При регистрации новый пользователь должен иметь права владельца
+        $user->setRoles(['ROLE_OWNER']);
         $form = $this->createForm(RegistrationFormType::class, $user);
         $form->handleRequest($request);
 

--- a/site/tests/Integration/Registration/RegistrationControllerTest.php
+++ b/site/tests/Integration/Registration/RegistrationControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Registration;
+
+use App\Entity\Company\User;
+use Doctrine\DBAL\Exception;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class RegistrationControllerTest extends WebTestCase
+{
+    private EntityManagerInterface $em;
+    private KernelBrowser $http;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->http = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->truncateTables(['user']);
+    }
+
+    public function testNewUserHasOwnerRole(): void
+    {
+        $crawler = $this->http->request('GET', '/register');
+
+        $form = $crawler->filter('form')->form([
+            'registration_form[email]' => 'owner@example.com',
+            'registration_form[plainPassword]' => 'secret12',
+            'registration_form[agreeTerms]' => true,
+        ]);
+        $this->http->submit($form);
+
+        self::assertResponseIsSuccessful();
+
+        /** @var User|null $user */
+        $user = $this->em->getRepository(User::class)->findOneBy(['email' => 'owner@example.com']);
+        self::assertNotNull($user);
+        self::assertContains('ROLE_OWNER', $user->getRoles());
+    }
+
+    /**
+     * @param list<string> $tables
+     * @throws Exception
+     */
+    private function truncateTables(array $tables): void
+    {
+        $conn = $this->em->getConnection();
+        $conn->executeStatement('BEGIN');
+        $conn->executeStatement('SET CONSTRAINTS ALL DEFERRED');
+        foreach ($tables as $table) {
+            $conn->executeStatement('TRUNCATE TABLE "'.$table.'" RESTART IDENTITY CASCADE');
+        }
+        $conn->executeStatement('COMMIT');
+    }
+}


### PR DESCRIPTION
## Summary
- assign `ROLE_OWNER` to users created via registration
- add integration test to verify owner role for new accounts

## Testing
- `make site-lint` *(fails: docker-compose: No such file or directory)*
- `composer install` *(fails: requires GitHub credentials)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a94755294c8323905399ab18dca8c7