### PR TITLE
Fix enum handling in company knowledge form

### DIFF
--- a/site/src/Form/AI/CompanyKnowledgeType.php
+++ b/site/src/Form/AI/CompanyKnowledgeType.php
@@ -4,6 +4,7 @@
 
 namespace App\Form\AI;
 
+use App\Entity\AI\Enum\KnowledgeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -16,17 +17,19 @@ class CompanyKnowledgeType extends AbstractType
     {
         $b->add('type', ChoiceType::class, [
             'label' => 'Тип',
-            'choices' => [
-                'FAQ' => 'faq',
-                'Доставка' => 'delivery',
-                'Продукты' => 'product',
-                'Политики' => 'policy',
-            ],
+            'choices' => KnowledgeType::cases(),
+            'choice_label' => fn(KnowledgeType $t) => match ($t) {
+                KnowledgeType::FAQ => 'FAQ',
+                KnowledgeType::DELIVERY => 'Доставка',
+                KnowledgeType::PRODUCT => 'Продукты',
+                KnowledgeType::POLICY => 'Политики',
+            },
+            'choice_value' => fn (?KnowledgeType $t) => $t?->value,
         ])
-            ->add('question', TextType::class, [
+            ->add('title', TextType::class, [
                 'label' => 'Заголовок/Вопрос',
             ])
-            ->add('answer', TextareaType::class, [
+            ->add('content', TextareaType::class, [
                 'label' => 'Ответ/Содержание',
                 'required' => false,
                 'attr' => ['rows' => 8],

--- a/site/templates/admin/ai/knowledge_form.html.twig
+++ b/site/templates/admin/ai/knowledge_form.html.twig
@@ -5,8 +5,8 @@
     <h1 class="text-xl font-semibold mb-4">Знание компании</h1>
     {{ form_start(form, { attr: { class: 'space-y-4 max-w-2xl' } }) }}
     {{ form_row(form.type) }}
-    {{ form_row(form.question) }}
-    {{ form_row(form.answer) }}
+    {{ form_row(form.title) }}
+    {{ form_row(form.content) }}
     <button class="px-4 py-2 bg-blue-600 text-white rounded">Сохранить</button>
     {{ form_end(form) }}
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix mapping for `KnowledgeType` enum in `CompanyKnowledgeType`
- use title and content fields in knowledge form template

## Testing
- `composer test` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab127c23b08323befc1a27d5c918c9