### PR TITLE
style: unify form element styling via Tailwind

### DIFF
--- a/site/assets/chat-center/components/SendMessageForm.tsx
+++ b/site/assets/chat-center/components/SendMessageForm.tsx
@@ -42,7 +42,7 @@ const SendMessageForm: React.FC<Props> = ({ clientId, onMessageSent }) => {
                 <input
                     {...register('message', { required: true })}
                     placeholder="Введите сообщение..."
-                    className="flex-1 px-4 py-2 border rounded"
+                    className="flex-1"
                 />
                 <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
                     ➤

--- a/site/assets/chat-center/components/SendMessageForm.tsx_
+++ b/site/assets/chat-center/components/SendMessageForm.tsx_
@@ -35,7 +35,7 @@ const SendMessageForm: React.FC<Props> = ({ clientId, onMessageSent }) => {
             <input
                 {...register('message', { required: true })}
                 placeholder="Введите сообщение..."
-                className="flex-1 px-4 py-2 border rounded"
+                className="flex-1"
             />
             <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
                 ➤

--- a/site/assets/styles/app.css
+++ b/site/assets/styles/app.css
@@ -4,3 +4,16 @@
 */
 
 @import 'tailwindcss';
+
+@layer base {
+    input:not([type='checkbox']):not([type='radio']):not([type='hidden']),
+    textarea,
+    select {
+        @apply block w-full rounded-md border-gray-300 bg-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500;
+    }
+
+    input[type='checkbox'],
+    input[type='radio'] {
+        @apply h-4 w-4 text-blue-600 border-gray-300 focus:ring-blue-500;
+    }
+}

--- a/site/templates/admin/ai_logs/index.html.twig
+++ b/site/templates/admin/ai_logs/index.html.twig
@@ -5,7 +5,7 @@
     <h1 class="text-xl font-semibold mb-3">AI Logs — последние 50</h1>
 
     <form method="get" class="mb-4 flex gap-2">
-        <input class="border rounded px-2 py-1" name="feature" placeholder="feature (e.g. intent_classify)" value="{{ feature|default('') }}">
+        <input class="flex-1" name="feature" placeholder="feature (e.g. intent_classify)" value="{{ feature|default('') }}">
         <button class="px-3 py-1 bg-gray-900 text-white rounded">Фильтр</button>
     </form>
 

--- a/site/templates/security/login.html.twig
+++ b/site/templates/security/login.html.twig
@@ -18,9 +18,9 @@
 
         <h2 class="text-center text-xl font-semibold mb-4">Please sign in</h2>
         <label for="username" class="block">Email</label>
-        <input type="email" value="{{ last_username }}" name="_username" id="username" class="mt-1 block w-full" autocomplete="email" required autofocus>
+        <input type="email" value="{{ last_username }}" name="_username" id="username" class="mt-1" autocomplete="email" required autofocus>
         <label for="password" class="block mt-4">Password</label>
-        <input type="password" name="_password" id="password" class="mt-1 block w-full" autocomplete="current-password" required>
+        <input type="password" name="_password" id="password" class="mt-1" autocomplete="current-password" required>
         <input type="hidden" name="_csrf_token" data-controller="csrf-protection" value="{{ csrf_token('authenticate') }}">
 
         {#


### PR DESCRIPTION
## Summary
- add base Tailwind styles to unify input, textarea, select, checkbox, and radio controls
- rely on global form styling in login, admin filters, and chat message components

## Testing
- `npm run build`
- `./bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18a9311c83239ef1a3f45cece217