### PR TITLE
Fix message timestamp display in MessageList

### DIFF
--- a/site/assets/chat-center/components/MessageList.tsx
+++ b/site/assets/chat-center/components/MessageList.tsx
@@ -11,6 +11,14 @@ type Message = {
     createdAt: string;
 };
 
+type ApiMessage = {
+    id: string;
+    text: string;
+    direction: 'in' | 'out';
+    timestamp?: string;
+    createdAt?: string;
+};
+
 type Props = {
     clientId: string;
     onNewMessage?: () => void;
@@ -22,7 +30,13 @@ const MessageList: React.FC<Props> = ({ clientId, onNewMessage }) => {
     useEffect(() => {
         if (!clientId) return;
         axios.get(`/api/messages/${clientId}`).then((res) => {
-            setMessages(res.data.messages);
+            const loadedMessages: Message[] = res.data.messages.map((msg: ApiMessage) => ({
+                id: msg.id,
+                text: msg.text,
+                direction: msg.direction,
+                createdAt: msg.createdAt || msg.timestamp || new Date().toISOString(),
+            }));
+            setMessages(loadedMessages);
             // После загрузки сообщений уведомляем родителя, чтобы прокрутить чат вниз
             onNewMessage && onNewMessage();
         });
@@ -52,7 +66,7 @@ const MessageList: React.FC<Props> = ({ clientId, onNewMessage }) => {
                 >
                     <div>{msg.text}</div>
                     <div className="text-xs text-right mt-1 opacity-70">
-                        {new Date(msg.createdAt).toLocaleTimeString()}
+                        {new Date(msg.createdAt).toLocaleString()}
                     </div>
                 </div>
             ))}


### PR DESCRIPTION
## Summary
- normalize message timestamps from API in MessageList
- render localized date and time for each message

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b04e4506dc83239f2e9eb786176d18