### PR TITLE
Redirect authenticated users to dashboard

### DIFF
--- a/site/config/packages/security.yaml
+++ b/site/config/packages/security.yaml
@@ -20,6 +20,7 @@ security:
                 login_path: app_login
                 check_path: app_login
                 enable_csrf: true
+                default_target_path: '/'
             logout:
                 path: app_logout
                 # where to redirect after logout

--- a/site/src/Controller/SecurityController.php
+++ b/site/src/Controller/SecurityController.php
@@ -12,6 +12,10 @@ class SecurityController extends AbstractController
     #[Route(path: '/login', name: 'app_login')]
     public function login(AuthenticationUtils $authenticationUtils): Response
     {
+        if (null !== $this->getUser()) {
+            return $this->redirectToRoute('dashboard');
+        }
+
         // get the login error if there is one
         $error = $authenticationUtils->getLastAuthenticationError();
 


### PR DESCRIPTION
## Summary
- redirect logged-in users away from login page
- send users to home page after successful login

## Testing
- `composer lint` *(fails: phplint: not found)*
- `composer test` *(fails: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b55e0c648323a6270f010bc7610b