### PR TITLE
feat: add company switcher widget

### DIFF
--- a/site/src/Controller/CompanySwitchController.php
+++ b/site/src/Controller/CompanySwitchController.php
@@ -7,6 +7,7 @@ use App\Repository\Company\UserCompanyRepository;
 use App\Service\Company\CompanyContextService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 class CompanySwitchController extends AbstractController
@@ -34,5 +35,15 @@ class CompanySwitchController extends AbstractController
         $context->setCompany($company);
 
         return $this->redirectToRoute('dashboard');
+    }
+
+    public function widget(UserCompanyRepository $repo, CompanyContextService $context): Response
+    {
+        $companies = $repo->findBy(['user' => $this->getUser()]);
+
+        return $this->render('company_switch/widget.html.twig', [
+            'companies' => $companies,
+            'activeCompany' => $context->getCompany(),
+        ]);
     }
 }

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -137,6 +137,9 @@
 
         <!-- Main content -->
         <main class="flex-1 p-8 overflow-auto">
+            <div class="mb-4 flex justify-end">
+                {{ render(controller('App\\Controller\\CompanySwitchController::widget')) }}
+            </div>
             {% set flashTypes = ['success', 'warning', 'danger', 'info'] %}
             {% set flashClasses = {
                 'success': 'border-green-400 bg-green-100 text-green-700',

--- a/site/templates/company_switch/widget.html.twig
+++ b/site/templates/company_switch/widget.html.twig
@@ -1,0 +1,9 @@
+{% set activeId = activeCompany ? activeCompany.id : null %}
+<div class="text-sm">
+    <label for="company-switcher" class="mr-2">Компания:</label>
+    <select id="company-switcher" class="border rounded px-2 py-1 bg-white" onchange="if(this.value) window.location.href=this.value;">
+        {% for uc in companies %}
+            <option value="{{ path('company.switch', {id: uc.company.id}) }}" {% if activeId == uc.company.id %}selected{% endif %}>{{ uc.company.name }}</option>
+        {% endfor %}
+    </select>
+</div>


### PR DESCRIPTION
## Summary
- render company switcher widget in base layout
- implement controller method and twig template for widget

## Testing
- `make site-lint` *(fails: docker-compose: No such file or directory)*
- `make site-test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fa4bfbe88323940bd7a9493e8655