### PR TITLE
Auto-select default company and keep current page when switching

### DIFF
--- a/site/src/Controller/CompanySwitchController.php
+++ b/site/src/Controller/CompanySwitchController.php
@@ -7,6 +7,7 @@ use App\Repository\Company\UserCompanyRepository;
 use App\Service\Company\CompanyContextService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -21,8 +22,12 @@ class CompanySwitchController extends AbstractController
     }
 
     #[Route('/companies/switch/{id}', name: 'company.switch')]
-    public function switch(Company $company, CompanyContextService $context, UserCompanyRepository $repo): RedirectResponse
-    {
+    public function switch(
+        Company $company,
+        CompanyContextService $context,
+        UserCompanyRepository $repo,
+        RequestStack $requestStack
+    ): RedirectResponse {
         $userCompany = $repo->findOneBy([
             'user' => $this->getUser(),
             'company' => $company,
@@ -33,6 +38,12 @@ class CompanySwitchController extends AbstractController
         }
 
         $context->setCompany($company);
+
+        $referer = $requestStack->getCurrentRequest()?->headers->get('referer');
+
+        if ($referer) {
+            return $this->redirect($referer);
+        }
 
         return $this->redirectToRoute('dashboard');
     }

--- a/site/src/Service/Company/CompanyContextService.php
+++ b/site/src/Service/Company/CompanyContextService.php
@@ -29,18 +29,44 @@ class CompanyContextService
 
         $session = $this->requestStack->getSession();
         $companyId = $session->get('active_company_id');
-        if (!$companyId) {
-            return null;
-        }
 
         /** @var User $user */
         $user = $this->security->getUser();
+
+        if (!$companyId) {
+            $userCompany = $this->userCompanyRepository->findOneBy([
+                'user' => $user,
+            ]);
+
+            if (!$userCompany) {
+                return null;
+            }
+
+            $this->setCompany($userCompany->getCompany());
+
+            return $this->currentCompany;
+        }
+
         $userCompany = $this->userCompanyRepository->findOneBy([
             'user' => $user,
             'company' => $companyId,
         ]);
 
-        return $this->currentCompany = $userCompany?->getCompany();
+        if (!$userCompany) {
+            $userCompany = $this->userCompanyRepository->findOneBy([
+                'user' => $user,
+            ]);
+
+            if (!$userCompany) {
+                return null;
+            }
+
+            $this->setCompany($userCompany->getCompany());
+
+            return $this->currentCompany;
+        }
+
+        return $this->currentCompany = $userCompany->getCompany();
     }
 
     public function setCompany(Company $company): void


### PR DESCRIPTION
## Summary
- Auto-select the first available company when no active company is set
- Redirect back to the current page after switching company via the widget

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `composer lint` *(fails: phplint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7fd09b7608323a4f5270634f106cd