### PR TITLE
Hide test refresh button in production environment

### DIFF
--- a/site/templates/chat/index.html.twig
+++ b/site/templates/chat/index.html.twig
@@ -6,10 +6,12 @@
 
 {% block body %}
     <h1 class="text-2xl font-bold mb-4">Чат-центр</h1>
-    <a href="{{ path('telegram_poll.test') }}"
-       class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded mb-4 inline-block">
-        + обновить тест
-    </a>
+    {% if app.environment != 'prod' %}
+        <a href="{{ path('telegram_poll.test') }}"
+           class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded mb-4 inline-block">
+            + обновить тест
+        </a>
+    {% endif %}
 
     <div id="chat-center-root"></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Hide test refresh button in chat center unless environment is non-production

## Testing
- `npm run build`
- `composer lint` *(fails: phplint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2519672188323b1d1f1f03ff15742