### PR TITLE
feat: enrich AI suggestions with knowledge context

### DIFF
--- a/site/src/Controller/Api/SuggestionController.php
+++ b/site/src/Controller/Api/SuggestionController.php
@@ -38,13 +38,24 @@ final class SuggestionController extends AbstractController
         // Rate-limit: не чаще 1 запроса / 3 сек на диалог
         if (!$this->limiter->acquire($company, $clientId)) {
             // "мягкая" отдача — пустой список, без 429
-            return $this->json(['suggestions' => []]);
+            return $this->json([
+                'suggestions' => [],
+                'knowledgeHitsCount' => 0,
+            ]);
         }
 
         /* throw new \DomainException('Company Id'.$company->getId().'--- Client Id'.$clientId); */
 
+        $result = $this->suggestions->suggest($company, $clientId);
+        $knowledgeHits = (int) ($result['knowledgeHitsCount'] ?? 0);
+        $suggestions = [];
+        if (isset($result['suggestions']) && is_array($result['suggestions'])) {
+            $suggestions = $result['suggestions'];
+        }
+
         return $this->json([
-            'suggestions' => $this->suggestions->suggest($company, $clientId),
+            'suggestions' => $suggestions,
+            'knowledgeHitsCount' => $knowledgeHits,
         ]);
     }
 }

--- a/site/src/Repository/AI/CompanyKnowledgeRepository.php
+++ b/site/src/Repository/AI/CompanyKnowledgeRepository.php
@@ -25,17 +25,17 @@ class CompanyKnowledgeRepository extends ServiceEntityRepository
     {
         $conn = $this->getEntityManager()->getConnection();
 
-        // если после normalizeQuery пришло пусто — безопасный fallback по заголовку
         if ('' === $query) {
-            $sql = '
-            SELECT id, title, LEFT(answer, 300) AS snippet, answer AS content,
-                   (0.2 * CASE WHEN priority > 0 THEN 1 ELSE 0 END) AS score,
-                   created_at
-            FROM company_knowledge
-            WHERE company_id = :company
-            ORDER BY priority DESC, created_at DESC
-            LIMIT :limit
-        ';
+            $sql = <<<SQL
+SELECT id, title, LEFT(answer, 300) AS snippet, answer AS content,
+       (0.2 * CASE WHEN priority > 0 THEN 1 ELSE 0 END) AS score,
+       created_at
+FROM company_knowledge
+WHERE company_id = :company
+ORDER BY priority DESC, created_at DESC
+LIMIT :limit
+SQL;
+
             $stmt = $conn->prepare($sql);
             $stmt->bindValue('company', $company->getId(), \PDO::PARAM_STR);
             $stmt->bindValue('limit', $limit, \PDO::PARAM_INT);
@@ -43,31 +43,37 @@ class CompanyKnowledgeRepository extends ServiceEntityRepository
             return $stmt->executeQuery()->fetchAllAssociative();
         }
 
-        $sql = "
-        SELECT id, title, LEFT(answer, 300) AS snippet, answer AS content,
-               (
-                   0.7 * ts_rank_cd(ts_ru, plainto_tsquery('russian', :q))
-                 + 0.3 * similarity(title, :q)
-                 + 0.2 * CASE WHEN priority > 0 THEN 1 ELSE 0 END
-                 ".($hintType ? ' + 0.2 * CASE WHEN type = :hintType THEN 1 ELSE 0 END ' : '')."
-               ) AS score,
-               created_at
-        FROM company_knowledge
-        WHERE company_id = :company
-          AND (
-                ts_ru @@ plainto_tsquery('russian', :q)
-             OR title ILIKE '%'||:q||'%'
-             OR answer ILIKE '%'||:q||'%'
-          )
-          ".(/* актуальность, если поля есть: */ false ? ' AND (valid_from IS NULL OR valid_from <= NOW()) AND (valid_to IS NULL OR valid_to >= NOW()) ' : '').'
-        ORDER BY score DESC, created_at DESC
-        LIMIT :limit
-    ';
+        $scoreParts = [
+            "0.7 * ts_rank_cd(ts_ru, plainto_tsquery('russian', :q))",
+            "0.3 * similarity(title, :q)",
+            "0.2 * CASE WHEN priority > 0 THEN 1 ELSE 0 END",
+        ];
+
+        if (null !== $hintType) {
+            $scoreParts[] = "0.2 * CASE WHEN type = :hintType THEN 1 ELSE 0 END";
+        }
+
+        $scoreExpr = implode(' + ', $scoreParts);
+
+        $sql = <<<SQL
+SELECT id, title, LEFT(answer, 300) AS snippet, answer AS content,
+       ({$scoreExpr}) AS score,
+       created_at
+FROM company_knowledge
+WHERE company_id = :company
+  AND (
+        ts_ru @@ plainto_tsquery('russian', :q)
+     OR title ILIKE '%'||:q||'%'
+     OR answer ILIKE '%'||:q||'%'
+  )
+ORDER BY score DESC, created_at DESC
+LIMIT :limit
+SQL;
 
         $stmt = $conn->prepare($sql);
         $stmt->bindValue('company', $company->getId(), \PDO::PARAM_STR);
         $stmt->bindValue('q', $query, \PDO::PARAM_STR);
-        if ($hintType) {
+        if (null !== $hintType) {
             $stmt->bindValue('hintType', $hintType, \PDO::PARAM_STR);
         }
         $stmt->bindValue('limit', $limit, \PDO::PARAM_INT);


### PR DESCRIPTION
## Summary
- enrich the suggestion context builder with company profile data, filtered knowledge snippets, and stricter query normalisation
- implement weighted SQL search with safe fallback for empty queries and expose last hit counts for telemetry
- surface knowledge hit metrics through the suggestion service/controller and show the count in the chat form UI

## Testing
- php -l site/src/AI/AiSuggestionContextService.php
- php -l site/src/Repository/AI/CompanyKnowledgeRepository.php
- php -l site/src/AI/SuggestionService.php
- php -l site/src/Controller/Api/SuggestionController.php


------
https://chatgpt.com/codex/tasks/task_e_68c9a2ae267883239d47c5459cc2f4e8