### PR TITLE
Remove redundant search columns from AI logs admin table

### DIFF
--- a/site/templates/admin/ai_logs/index.html.twig
+++ b/site/templates/admin/ai_logs/index.html.twig
@@ -23,9 +23,6 @@
                 <th class="p-2 text-left">Prompt</th>
                 <th class="p-2 text-left">Response</th>
                 <th class="p-2 text-left">Search (JSON)</th>
-                {# NEW COLUMNS #}
-                <th class="p-2 text-left">Search: raw_query</th>
-                <th class="p-2 text-left">Search: norm_query</th>
             </tr>
             </thead>
             <tbody>
@@ -59,20 +56,9 @@
                         } %}
                         <pre class="text-xs whitespace-pre-wrap bg-gray-50 border rounded p-2">{{ searchBlock|json_encode(constant('JSON_UNESCAPED_UNICODE') b-or constant('JSON_PRETTY_PRINT')) }}</pre>
                     </td>
-                    {# NEW CELL: raw_query #}
-                    <td class="p-2 text-xs">
-                        {% set rq = r.metadata.search.raw_query ?? '' %}
-                        {{ rq is iterable ? '' : (rq|slice(0,120)|e) }}{% if rq is not iterable and rq|length > 120 %}…{% endif %}
-                    </td>
-
-                    {# NEW CELL: norm_query #}
-                    <td class="p-2 text-xs">
-                        {% set nq = r.metadata.search.norm_query ?? '' %}
-                        {{ nq is iterable ? '' : (nq|slice(0,120)|e) }}{% if nq is not iterable and nq|length > 120 %}…{% endif %}
-                    </td>
                 </tr>
             {% else %}
-                <tr><td colspan="12" class="p-4 text-center text-gray-500">Нет записей.</td></tr>
+                <tr><td colspan="10" class="p-4 text-center text-gray-500">Нет записей.</td></tr>
             {% endfor %}
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- remove the raw_query and norm_query columns from the AI logs admin report table
- update the empty-state colspan to match the reduced column count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c1d608b48323b9187383fbb2affe