### PR TITLE
Install intl extension in production PHP images

### DIFF
--- a/site/docker/production/php-cli/Dockerfile
+++ b/site/docker/production/php-cli/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.2-fpm-alpine AS builder
 
-RUN apk add --no-cache libpq-dev \
+RUN apk add --no-cache git libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql opcache
 
@@ -21,9 +21,10 @@ RUN composer install --no-dev --prefer-dist --no-progress --no-scripts --optimiz
 
 FROM php:8.2-cli-alpine
 
-RUN apk add --no-cache libpq-dev bash coreutils \
+RUN apk add --no-cache bash coreutils icu-dev libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl pdo_pgsql opcache
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 

--- a/site/docker/production/php-fpm/Dockerfile
+++ b/site/docker/production/php-fpm/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.2-cli-alpine AS builder
 
-RUN apk add --no-cache libpq-dev \
+RUN apk add --no-cache git libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql opcache
 
@@ -31,9 +31,10 @@ RUN yarn build
 ### FPM ###
 FROM php:8.2-fpm-alpine
 
-RUN apk add --no-cache libpq-dev fcgi \
+RUN apk add --no-cache fcgi icu-dev libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
-    && docker-php-ext-install pdo_pgsql opcache
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install intl pdo_pgsql opcache
 
 RUN mv $PHP_INI_DIR/php.ini-production $PHP_INI_DIR/php.ini
 


### PR DESCRIPTION
## Summary
- add git to the PHP builder stages so Composer can fall back to git clones when dist archives are unavailable
- compile the intl extension in the production PHP CLI and FPM images to satisfy Symfony runtime requirements

## Testing
- not run (Docker image build change only)


------
https://chatgpt.com/codex/tasks/task_e_68cb8ee5faec8323918541192f6856d0