### PR TITLE
Add monolog channel for AI knowledge logging

### DIFF
--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - ai.knowledge
 
 when@dev:
     monolog:


### PR DESCRIPTION
## Summary
- register the `ai.knowledge` monolog channel so the AI suggestion context service can autowire its logger

## Testing
- php bin/console lint:container *(fails: missing composer dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb9db795c8832381bdd29bd5695c55