### PR TITLE
Add CRM log channel and handler

### DIFF
--- a/site/config/packages/monolog.yaml
+++ b/site/config/packages/monolog.yaml
@@ -2,6 +2,13 @@ monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
         - ai.knowledge
+        - crm
+    handlers:
+        crm:
+            type: stream
+            path: "%kernel.logs_dir%/crm.log"
+            level: info
+            channels: ["crm"]
 
 when@dev:
     monolog:


### PR DESCRIPTION
## Summary
- add the crm channel to the Monolog configuration
- define a stream handler for crm logs that writes to crm.log at info level

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cea6259a4883239042b1751084caad