### PR TITLE
Fix CRM API route import definition

### DIFF
--- a/site/config/routes/crm_api.yaml
+++ b/site/config/routes/crm_api.yaml
@@ -1,3 +1,4 @@
-resource: '../../src/Controller/Api/Crm/'
-type: attribute
-prefix: /api/crm
+crm_api:
+  resource: '../../src/Controller/Api/Crm/'
+  type: attribute
+  prefix: /api/crm


### PR DESCRIPTION
## Summary
- wrap the CRM API route import configuration in a named key so Symfony reads it correctly

## Testing
- php bin/console lint:yaml config/routes/crm_api.yaml *(fails: project dependencies are not installed and composer install requires GitHub authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68cea8464bd483239470db8670d150e8