### PR TITLE
Add CRM pipeline entity and migration

### DIFF
--- a/site/migrations/Version20250830090000.php
+++ b/site/migrations/Version20250830090000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250830090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create CRM pipelines table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "crm_pipelines" (id UUID NOT NULL, company_id UUID NOT NULL, name VARCHAR(120) NOT NULL, slug VARCHAR(140) NOT NULL, is_default BOOLEAN DEFAULT FALSE NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_2E32ED83979B1AD6 ON "crm_pipelines" (company_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2E32ED83979B1AD6989D9B62 ON "crm_pipelines" (company_id, slug)');
+        $this->addSql('COMMENT ON COLUMN "crm_pipelines".created_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN "crm_pipelines".updated_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('ALTER TABLE "crm_pipelines" ADD CONSTRAINT FK_2E32ED83979B1AD6 FOREIGN KEY (company_id) REFERENCES "companies" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "crm_pipelines" DROP CONSTRAINT FK_2E32ED83979B1AD6');
+        $this->addSql('DROP TABLE "crm_pipelines"');
+    }
+}

--- a/site/src/Entity/Crm/CrmPipeline.php
+++ b/site/src/Entity/Crm/CrmPipeline.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Entity\Crm;
+
+use App\Entity\Company\Company;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`crm_pipelines`')]
+#[ORM\UniqueConstraint(name: 'crm_pipeline_company_slug_unique', fields: ['company', 'slug'])]
+class CrmPipeline
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\Column(length: 120)]
+    private string $name;
+
+    #[ORM\Column(length: 140)]
+    private string $slug;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isDefault = false;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, Company $company)
+    {
+        Assert::uuid($id);
+        $this->id = $id;
+        $this->company = $company;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): void
+    {
+        $this->slug = $slug;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function setIsDefault(bool $isDefault): void
+    {
+        $this->isDefault = $isDefault;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}


### PR DESCRIPTION
## Summary
- add CRM pipeline entity with company relation and timestamp fields
- create migration to persist CRM pipelines with unique company slug constraint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cea9704f788323826252f9374d3fa8