### PR TITLE
Add CRM stage entity and migration

### DIFF
--- a/site/migrations/Version20250830100000.php
+++ b/site/migrations/Version20250830100000.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250830100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create CRM stages table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "crm_stages" (id UUID NOT NULL, pipeline_id UUID NOT NULL, name VARCHAR(80) NOT NULL, position INT NOT NULL, color VARCHAR(7) DEFAULT ''#CBD5E1'' NOT NULL, probability SMALLINT DEFAULT 0 NOT NULL, is_start BOOLEAN DEFAULT FALSE NOT NULL, is_won BOOLEAN DEFAULT FALSE NOT NULL, is_lost BOOLEAN DEFAULT FALSE NOT NULL, sla_hours INT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_CRM_STAGES_PIPELINE_ID ON "crm_stages" (pipeline_id)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CRM_STAGES_PIPELINE_POSITION ON "crm_stages" (pipeline_id, position)');
+        $this->addSql('COMMENT ON COLUMN "crm_stages".created_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('COMMENT ON COLUMN "crm_stages".updated_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('ALTER TABLE "crm_stages" ADD CONSTRAINT FK_CRM_STAGES_PIPELINE FOREIGN KEY (pipeline_id) REFERENCES "crm_pipelines" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "crm_stages" DROP CONSTRAINT FK_CRM_STAGES_PIPELINE');
+        $this->addSql('DROP TABLE "crm_stages"');
+    }
+}

--- a/site/src/Entity/Crm/CrmStage.php
+++ b/site/src/Entity/Crm/CrmStage.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Entity\Crm;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`crm_stages`')]
+#[ORM\UniqueConstraint(name: 'crm_stage_pipeline_position_unique', fields: ['pipeline', 'position'])]
+class CrmStage
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private CrmPipeline $pipeline;
+
+    #[ORM\Column(length: 80)]
+    private string $name;
+
+    #[ORM\Column(type: 'integer')]
+    private int $position;
+
+    #[ORM\Column(length: 7, options: ['default' => '#CBD5E1'])]
+    private string $color = '#CBD5E1';
+
+    #[ORM\Column(type: 'smallint', options: ['default' => 0])]
+    private int $probability = 0;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isStart = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isWon = false;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isLost = false;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $slaHours = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $id, CrmPipeline $pipeline)
+    {
+        Assert::uuid($id);
+
+        $this->id = $id;
+        $this->pipeline = $pipeline;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getPipeline(): CrmPipeline
+    {
+        return $this->pipeline;
+    }
+
+    public function setPipeline(CrmPipeline $pipeline): void
+    {
+        $this->pipeline = $pipeline;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function getColor(): string
+    {
+        return $this->color;
+    }
+
+    public function setColor(string $color): void
+    {
+        $this->color = $color;
+    }
+
+    public function getProbability(): int
+    {
+        return $this->probability;
+    }
+
+    public function setProbability(int $probability): void
+    {
+        $this->probability = $probability;
+    }
+
+    public function isStart(): bool
+    {
+        return $this->isStart;
+    }
+
+    public function setIsStart(bool $isStart): void
+    {
+        $this->isStart = $isStart;
+    }
+
+    public function isWon(): bool
+    {
+        return $this->isWon;
+    }
+
+    public function setIsWon(bool $isWon): void
+    {
+        $this->isWon = $isWon;
+    }
+
+    public function isLost(): bool
+    {
+        return $this->isLost;
+    }
+
+    public function setIsLost(bool $isLost): void
+    {
+        $this->isLost = $isLost;
+    }
+
+    public function getSlaHours(): ?int
+    {
+        return $this->slaHours;
+    }
+
+    public function setSlaHours(?int $slaHours): void
+    {
+        $this->slaHours = $slaHours;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+
+    #[Assert\Callback]
+    public function validate(ExecutionContextInterface $context): void
+    {
+        if ($this->isWon && $this->isLost) {
+            $context
+                ->buildViolation('A stage cannot be both won and lost.')
+                ->atPath('isWon')
+                ->addViolation();
+
+            $context
+                ->buildViolation('A stage cannot be both won and lost.')
+                ->atPath('isLost')
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a CRM stage entity with UUID identity, defaults, and validation preventing conflicting win/loss states
- create the crm_stages table migration with cascade delete, unique constraint, and timestamp metadata

## Testing
- composer lint *(fails: `phplint` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cebf8a955083238906001c917f5776