### PR TITLE
Add CRM deal entity and migration

### DIFF
--- a/site/migrations/Version20250830110000.php
+++ b/site/migrations/Version20250830110000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250830110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create CRM deals table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "crm_deals" (id UUID NOT NULL, company_id UUID NOT NULL, pipeline_id UUID NOT NULL, stage_id UUID NOT NULL, client_id UUID DEFAULT NULL, owner_id UUID DEFAULT NULL, created_by_id UUID NOT NULL, title VARCHAR(160) NOT NULL, amount NUMERIC(14, 2) DEFAULT NULL, currency CHAR(3) DEFAULT ''RUB'' NOT NULL, source VARCHAR(40) DEFAULT NULL, meta JSONB DEFAULT ''{}''::jsonb NOT NULL, opened_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, closed_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, is_closed BOOLEAN DEFAULT FALSE NOT NULL, loss_reason VARCHAR(120) DEFAULT NULL, note TEXT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_CRM_DEALS_COMPANY_PIPELINE ON "crm_deals" (company_id, pipeline_id)');
+        $this->addSql('CREATE INDEX IDX_CRM_DEALS_STAGE ON "crm_deals" (stage_id)');
+        $this->addSql('COMMENT ON COLUMN "crm_deals".opened_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('COMMENT ON COLUMN "crm_deals".closed_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('COMMENT ON COLUMN "crm_deals".created_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('COMMENT ON COLUMN "crm_deals".updated_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_COMPANY FOREIGN KEY (company_id) REFERENCES "companies" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_PIPELINE FOREIGN KEY (pipeline_id) REFERENCES "crm_pipelines" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_STAGE FOREIGN KEY (stage_id) REFERENCES "crm_stages" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_CLIENT FOREIGN KEY (client_id) REFERENCES "clients" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_OWNER FOREIGN KEY (owner_id) REFERENCES "user" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_deals" ADD CONSTRAINT FK_CRM_DEALS_CREATED_BY FOREIGN KEY (created_by_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_COMPANY');
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_PIPELINE');
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_STAGE');
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_CLIENT');
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_OWNER');
+        $this->addSql('ALTER TABLE "crm_deals" DROP CONSTRAINT FK_CRM_DEALS_CREATED_BY');
+        $this->addSql('DROP TABLE "crm_deals"');
+    }
+}

--- a/site/src/Entity/Crm/CrmDeal.php
+++ b/site/src/Entity/Crm/CrmDeal.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Entity\Crm;
+
+use App\Entity\Company\Company;
+use App\Entity\Company\User;
+use App\Entity\Messaging\Client;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`crm_deals`')]
+#[ORM\Index(name: 'idx_crm_deals_company_pipeline', columns: ['company_id', 'pipeline_id'])]
+#[ORM\Index(name: 'idx_crm_deals_stage', columns: ['stage_id'])]
+class CrmDeal
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Company $company;
+
+    #[ORM\ManyToOne(targetEntity: CrmPipeline::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private CrmPipeline $pipeline;
+
+    #[ORM\ManyToOne(targetEntity: CrmStage::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private CrmStage $stage;
+
+    #[ORM\ManyToOne(targetEntity: Client::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?Client $client = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?User $owner = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $createdBy;
+
+    #[ORM\Column(length: 160)]
+    private string $title;
+
+    #[ORM\Column(type: 'decimal', precision: 14, scale: 2, nullable: true)]
+    private ?string $amount = null;
+
+    #[ORM\Column(type: 'string', length: 3, options: ['default' => 'RUB', 'fixed' => true])]
+    private string $currency = 'RUB';
+
+    #[ORM\Column(length: 40, nullable: true)]
+    private ?string $source = null;
+
+    #[ORM\Column(type: 'jsonb', options: ['default' => '{}'])]
+    private array $meta = [];
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $openedAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private ?\DateTimeImmutable $closedAt = null;
+
+    #[ORM\Column(type: 'boolean', options: ['default' => false])]
+    private bool $isClosed = false;
+
+    #[ORM\Column(length: 120, nullable: true)]
+    private ?string $lossReason = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    private ?string $note = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $id,
+        Company $company,
+        CrmPipeline $pipeline,
+        CrmStage $stage,
+        User $createdBy,
+        string $title,
+        \DateTimeImmutable $openedAt,
+    ) {
+        Assert::uuid($id);
+
+        $this->id = $id;
+        $this->company = $company;
+        $this->pipeline = $pipeline;
+        $this->stage = $stage;
+        $this->createdBy = $createdBy;
+        $this->title = $title;
+        $this->openedAt = $openedAt;
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): Company
+    {
+        return $this->company;
+    }
+
+    public function setCompany(Company $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getPipeline(): CrmPipeline
+    {
+        return $this->pipeline;
+    }
+
+    public function setPipeline(CrmPipeline $pipeline): void
+    {
+        $this->pipeline = $pipeline;
+    }
+
+    public function getStage(): CrmStage
+    {
+        return $this->stage;
+    }
+
+    public function setStage(CrmStage $stage): void
+    {
+        $this->stage = $stage;
+    }
+
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(?Client $client): void
+    {
+        $this->client = $client;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): void
+    {
+        $this->owner = $owner;
+    }
+
+    public function getCreatedBy(): User
+    {
+        return $this->createdBy;
+    }
+
+    public function setCreatedBy(User $createdBy): void
+    {
+        $this->createdBy = $createdBy;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getAmount(): ?string
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(?string $amount): void
+    {
+        $this->amount = $amount;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): void
+    {
+        $this->currency = $currency;
+    }
+
+    public function getSource(): ?string
+    {
+        return $this->source;
+    }
+
+    public function setSource(?string $source): void
+    {
+        $this->source = $source;
+    }
+
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    public function setMeta(array $meta): void
+    {
+        $this->meta = $meta;
+    }
+
+    public function getOpenedAt(): \DateTimeImmutable
+    {
+        return $this->openedAt;
+    }
+
+    public function setOpenedAt(\DateTimeImmutable $openedAt): void
+    {
+        $this->openedAt = $openedAt;
+    }
+
+    public function getClosedAt(): ?\DateTimeImmutable
+    {
+        return $this->closedAt;
+    }
+
+    public function setClosedAt(?\DateTimeImmutable $closedAt): void
+    {
+        $this->closedAt = $closedAt;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->isClosed;
+    }
+
+    public function setIsClosed(bool $isClosed): void
+    {
+        $this->isClosed = $isClosed;
+    }
+
+    public function getLossReason(): ?string
+    {
+        return $this->lossReason;
+    }
+
+    public function setLossReason(?string $lossReason): void
+    {
+        $this->lossReason = $lossReason;
+    }
+
+    public function getNote(): ?string
+    {
+        return $this->note;
+    }
+
+    public function setNote(?string $note): void
+    {
+        $this->note = $note;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}


### PR DESCRIPTION
## Summary
- add CRM deal Doctrine entity with required associations, defaults, and timestamps
- create PostgreSQL migration to introduce crm_deals table with indexes and foreign keys

## Testing
- composer lint *(fails: phplint not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec0dc2fb08323a04ae17216eb238a