### PR TITLE
Add CRM stage history entity and migration

### DIFF
--- a/site/migrations/Version20250830120000.php
+++ b/site/migrations/Version20250830120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250830120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create CRM stage history table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE "crm_stage_history" (id UUID NOT NULL, deal_id UUID NOT NULL, from_stage_id UUID DEFAULT NULL, to_stage_id UUID NOT NULL, changed_by_id UUID NOT NULL, changed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, comment VARCHAR(240) DEFAULT NULL, spent_hours INT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_CRM_STAGE_HISTORY_DEAL ON "crm_stage_history" (deal_id)');
+        $this->addSql('COMMENT ON COLUMN "crm_stage_history".changed_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_DEAL FOREIGN KEY (deal_id) REFERENCES "crm_deals" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_FROM_STAGE FOREIGN KEY (from_stage_id) REFERENCES "crm_stages" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_TO_STAGE FOREIGN KEY (to_stage_id) REFERENCES "crm_stages" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_CHANGED_BY FOREIGN KEY (changed_by_id) REFERENCES "user" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "crm_stage_history" DROP CONSTRAINT FK_CRM_STAGE_HISTORY_DEAL');
+        $this->addSql('ALTER TABLE "crm_stage_history" DROP CONSTRAINT FK_CRM_STAGE_HISTORY_FROM_STAGE');
+        $this->addSql('ALTER TABLE "crm_stage_history" DROP CONSTRAINT FK_CRM_STAGE_HISTORY_TO_STAGE');
+        $this->addSql('ALTER TABLE "crm_stage_history" DROP CONSTRAINT FK_CRM_STAGE_HISTORY_CHANGED_BY');
+        $this->addSql('DROP TABLE "crm_stage_history"');
+    }
+}

--- a/site/src/Entity/Crm/CrmStageHistory.php
+++ b/site/src/Entity/Crm/CrmStageHistory.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Entity\Crm;
+
+use App\Entity\Company\User;
+use Doctrine\ORM\Mapping as ORM;
+use Webmozart\Assert\Assert;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`crm_stage_history`')]
+#[ORM\Index(name: 'idx_crm_stage_history_deal', columns: ['deal_id'])]
+class CrmStageHistory
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'guid', unique: true)]
+    private ?string $id = null;
+
+    #[ORM\ManyToOne(targetEntity: CrmDeal::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private CrmDeal $deal;
+
+    #[ORM\ManyToOne(targetEntity: CrmStage::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?CrmStage $fromStage = null;
+
+    #[ORM\ManyToOne(targetEntity: CrmStage::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private CrmStage $toStage;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $changedBy;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private \DateTimeImmutable $changedAt;
+
+    #[ORM\Column(length: 240, nullable: true)]
+    private ?string $comment = null;
+
+    #[ORM\Column(type: 'integer', nullable: true)]
+    private ?int $spentHours = null;
+
+    public function __construct(
+        string $id,
+        CrmDeal $deal,
+        CrmStage $toStage,
+        User $changedBy,
+        \DateTimeImmutable $changedAt,
+        ?CrmStage $fromStage = null,
+    ) {
+        Assert::uuid($id);
+
+        $this->id = $id;
+        $this->deal = $deal;
+        $this->toStage = $toStage;
+        $this->changedBy = $changedBy;
+        $this->changedAt = $changedAt;
+        $this->fromStage = $fromStage;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getDeal(): CrmDeal
+    {
+        return $this->deal;
+    }
+
+    public function setDeal(CrmDeal $deal): void
+    {
+        $this->deal = $deal;
+    }
+
+    public function getFromStage(): ?CrmStage
+    {
+        return $this->fromStage;
+    }
+
+    public function setFromStage(?CrmStage $fromStage): void
+    {
+        $this->fromStage = $fromStage;
+    }
+
+    public function getToStage(): CrmStage
+    {
+        return $this->toStage;
+    }
+
+    public function setToStage(CrmStage $toStage): void
+    {
+        $this->toStage = $toStage;
+    }
+
+    public function getChangedBy(): User
+    {
+        return $this->changedBy;
+    }
+
+    public function setChangedBy(User $changedBy): void
+    {
+        $this->changedBy = $changedBy;
+    }
+
+    public function getChangedAt(): \DateTimeImmutable
+    {
+        return $this->changedAt;
+    }
+
+    public function setChangedAt(\DateTimeImmutable $changedAt): void
+    {
+        $this->changedAt = $changedAt;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $comment): void
+    {
+        $this->comment = $comment;
+    }
+
+    public function getSpentHours(): ?int
+    {
+        return $this->spentHours;
+    }
+
+    public function setSpentHours(?int $spentHours): void
+    {
+        $this->spentHours = $spentHours;
+    }
+}


### PR DESCRIPTION
## Summary
- add the CrmStageHistory entity to store deal stage transitions with metadata and index on deal references
- create the crm_stage_history PostgreSQL migration including constraints and immutable timestamp comment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec2115a388323a12d70b438412e7a