### PR TITLE
Fix Assert alias conflict in CRM stage entity

### DIFF
--- a/site/src/Entity/Crm/CrmStage.php
+++ b/site/src/Entity/Crm/CrmStage.php
@@ -5,7 +5,7 @@ namespace App\Entity\Crm;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Webmozart\Assert\Assert;
+use Webmozart\Assert\Assert as WebmozartAssert;
 
 #[ORM\Entity]
 #[ORM\Table(name: '`crm_stages`')]
@@ -52,7 +52,7 @@ class CrmStage
 
     public function __construct(string $id, CrmPipeline $pipeline)
     {
-        Assert::uuid($id);
+        WebmozartAssert::uuid($id);
 
         $this->id = $id;
         $this->pipeline = $pipeline;


### PR DESCRIPTION
## Summary
- alias Webmozart Assert to avoid clashing with Symfony's Assert namespace alias
- update CRM stage constructor to reference the new alias

## Testing
- composer test *(fails: phpunit executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cec5906d508323918c81d879ac15dc