### PR TITLE
Fix quoting in CRM stages migration

### DIFF
--- a/site/migrations/Version20250830100000.php
+++ b/site/migrations/Version20250830100000.php
@@ -16,11 +16,11 @@ final class Version20250830100000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE "crm_stages" (id UUID NOT NULL, pipeline_id UUID NOT NULL, name VARCHAR(80) NOT NULL, position INT NOT NULL, color VARCHAR(7) DEFAULT ''#CBD5E1'' NOT NULL, probability SMALLINT DEFAULT 0 NOT NULL, is_start BOOLEAN DEFAULT FALSE NOT NULL, is_won BOOLEAN DEFAULT FALSE NOT NULL, is_lost BOOLEAN DEFAULT FALSE NOT NULL, sla_hours INT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE "crm_stages" (id UUID NOT NULL, pipeline_id UUID NOT NULL, name VARCHAR(80) NOT NULL, position INT NOT NULL, color VARCHAR(7) DEFAULT \'#CBD5E1\' NOT NULL, probability SMALLINT DEFAULT 0 NOT NULL, is_start BOOLEAN DEFAULT FALSE NOT NULL, is_won BOOLEAN DEFAULT FALSE NOT NULL, is_lost BOOLEAN DEFAULT FALSE NOT NULL, sla_hours INT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE INDEX IDX_CRM_STAGES_PIPELINE_ID ON "crm_stages" (pipeline_id)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_CRM_STAGES_PIPELINE_POSITION ON "crm_stages" (pipeline_id, position)');
-        $this->addSql('COMMENT ON COLUMN "crm_stages".created_at IS ''(DC2Type:datetime_immutable)''');
-        $this->addSql('COMMENT ON COLUMN "crm_stages".updated_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql('COMMENT ON COLUMN "crm_stages".created_at IS \'(DC2Type:datetime_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN "crm_stages".updated_at IS \'(DC2Type:datetime_immutable)\'');
         $this->addSql('ALTER TABLE "crm_stages" ADD CONSTRAINT FK_CRM_STAGES_PIPELINE FOREIGN KEY (pipeline_id) REFERENCES "crm_pipelines" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
     }
 


### PR DESCRIPTION
## Summary
- escape the single quotes in the CRM stages migration SQL so the file parses correctly
- fix the column comment statements to use proper PHP quoting

## Testing
- php -l migrations/Version20250830100000.php

------
https://chatgpt.com/codex/tasks/task_e_68cec6d786ec83238e71ba2259abf5b5