### PR TITLE
Fix quoting in CRM stage history migration

### DIFF
--- a/site/migrations/Version20250830120000.php
+++ b/site/migrations/Version20250830120000.php
@@ -18,7 +18,7 @@ final class Version20250830120000 extends AbstractMigration
     {
         $this->addSql('CREATE TABLE "crm_stage_history" (id UUID NOT NULL, deal_id UUID NOT NULL, from_stage_id UUID DEFAULT NULL, to_stage_id UUID NOT NULL, changed_by_id UUID NOT NULL, changed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, comment VARCHAR(240) DEFAULT NULL, spent_hours INT DEFAULT NULL, PRIMARY KEY(id))');
         $this->addSql('CREATE INDEX IDX_CRM_STAGE_HISTORY_DEAL ON "crm_stage_history" (deal_id)');
-        $this->addSql('COMMENT ON COLUMN "crm_stage_history".changed_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql("COMMENT ON COLUMN \"crm_stage_history\".changed_at IS '(DC2Type:datetime_immutable)'");
         $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_DEAL FOREIGN KEY (deal_id) REFERENCES "crm_deals" (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_FROM_STAGE FOREIGN KEY (from_stage_id) REFERENCES "crm_stages" (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE "crm_stage_history" ADD CONSTRAINT FK_CRM_STAGE_HISTORY_TO_STAGE FOREIGN KEY (to_stage_id) REFERENCES "crm_stages" (id) NOT DEFERRABLE INITIALLY IMMEDIATE');


### PR DESCRIPTION
## Summary
- fix the SQL comment string quoting in the CRM stage history migration to prevent PHP parse errors during deployment

## Testing
- php -l site/migrations/Version20250830120000.php

------
https://chatgpt.com/codex/tasks/task_e_68cecb07b99083238ec5c0f8a16f2978