### PR TITLE
Add CRM page and navigation link

### DIFF
--- a/site/src/Controller/CrmController.php
+++ b/site/src/Controller/CrmController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CrmController extends AbstractController
+{
+    #[Route('/crm', name: 'crm.index', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('crm/index.html.twig');
+    }
+}

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -35,6 +35,12 @@
                         💬 Чат-центр
                     </a>
 
+                    <a href="{{ path('crm.index') }}"
+                       class="block px-3 py-2 rounded hover:bg-gray-800
+                              {{ app.request.attributes.get('_route') starts with 'crm.' ? 'bg-gray-800' : '' }}">
+                        📊 CRM
+                    </a>
+
                     <a href="#" class="block px-3 py-2 rounded hover:bg-gray-800">
                         🧠 Сценарии <span class="text-xs text-gray-400">(в разработке)</span>
                     </a>

--- a/site/templates/crm/index.html.twig
+++ b/site/templates/crm/index.html.twig
@@ -1,0 +1,9 @@
+{# templates/crm/index.html.twig #}
+{% extends 'base.html.twig' %}
+
+{% block title %}CRM{% endblock %}
+
+{% block body %}
+    <h1 class="text-2xl font-bold mb-4">CRM</h1>
+    <div id="crm-root"></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Symfony controller and Twig template to serve a simple CRM page
- expose the CRM page in the sidebar navigation with active route highlighting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee19be08c83238743fbc0cce32fa3