### PR TITLE
Add CRM layout skeleton components

### DIFF
--- a/site/assets/crm/components/CrmLayout.tsx
+++ b/site/assets/crm/components/CrmLayout.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import PipelineList from './PipelineList';
+import FiltersBar from './FiltersBar';
+import DealBoard from './DealBoard';
+import DealProfile from './DealProfile';
+
+export type Deal = {
+  id: string; title: string; value?: number;
+  client: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> };
+  channelType?: string; unread?: number; assignee?: string;
+  pipelineId: string; stageId: string; updatedAt?: number; daysInStage?: number;
+};
+
+export default function CrmLayout() {
+  const [activePipelineId, setActivePipelineId] = useState<string | null>(null);
+  const [activeDeal, setActiveDeal] = useState<Deal | null>(null);
+  const [filters, setFilters] = useState<{ assignee: string | 'all'; channel: string | 'all'; q: string }>({
+    assignee: 'all', channel: 'all', q: ''
+  });
+
+  return (
+    <div className="h-full grid grid-cols-12 gap-4">
+      <aside className="col-span-2 bg-white rounded-2xl border p-3">
+        <div className="flex items-center gap-2 mb-3"><div className="text-lg font-semibold">Воронки</div></div>
+        <PipelineList activeId={activePipelineId} onSelect={setActivePipelineId} />
+      </aside>
+
+      <main className="col-span-7 bg-white rounded-2xl border flex flex-col">
+        <div className="p-3 border-b flex items-center gap-3">
+          <FiltersBar value={filters} onChange={setFilters} />
+          <button className="ml-auto px-3 py-2 rounded-xl border hover:bg-gray-50">Новая сделка</button>
+        </div>
+        <div className="flex-1 p-3 overflow-auto">
+          <DealBoard pipelineId={activePipelineId} filters={filters} onOpenDeal={setActiveDeal} />
+        </div>
+      </main>
+
+      <aside className="col-span-3 bg-white rounded-2xl border p-3">
+        <DealProfile deal={activeDeal} />
+      </aside>
+    </div>
+  );
+}

--- a/site/assets/crm/components/DealBoard.tsx
+++ b/site/assets/crm/components/DealBoard.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect, useState } from 'react';
+type Props = {
+  pipelineId: string | null;
+  filters: { assignee: string | 'all'; channel: string | 'all'; q: string };
+  onOpenDeal: (deal: any) => void;
+};
+export default function DealBoard({ pipelineId, filters, onOpenDeal }: Props) {
+  const [stages, setStages] = useState<Array<{ id: string; name: string; wip?: number }>>([]);
+  const [dealsByStage, setDealsByStage] = useState<Record<string, any[]>>({});
+  useEffect(() => { setStages([]); setDealsByStage({}); }, [pipelineId, filters]);
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      {stages.map((s) => (
+        <div key={s.id} className="flex flex-col rounded-2xl border bg-white">
+          <div className="p-3 border-b"><div className="font-semibold">{s.name}</div></div>
+          <div className="p-3 space-y-2">
+            {(dealsByStage[s.id] || []).map((d) => (
+              <button key={d.id} onClick={() => onOpenDeal(d)} className="rounded-2xl border bg-white p-3 shadow-sm text-left">
+                <div className="font-semibold">{d.title}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/site/assets/crm/components/DealProfile.tsx
+++ b/site/assets/crm/components/DealProfile.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+type Deal = {
+  id: string; title: string; value?: number;
+  client: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> };
+  unread?: number; daysInStage?: number;
+};
+export default function DealProfile({ deal }: { deal: Deal | null }) {
+  if (!deal) return <div className="h-full flex items-center justify-center text-sm text-gray-500">Выберите сделку</div>;
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-start gap-3">
+        <div className="w-12 h-12 rounded-2xl bg-gray-100 flex items-center justify-center font-semibold">
+          {(deal.client.name || '').split(' ').map(s => s[0]).slice(0,2).join('')}
+        </div>
+        <div className="flex-1">
+          <div className="font-semibold leading-tight">{deal.client.name}</div>
+          <div className="text-xs text-gray-500">ID клиента: {deal.client.id}</div>
+        </div>
+        <div className="text-right">
+          <div className="text-sm font-semibold">{deal.value ? `${deal.value} ₽` : ''}</div>
+          <div className="text-xs text-gray-500">{deal.title}</div>
+        </div>
+      </div>
+      <div className="mt-4">
+        <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Каналы</div>
+        <div className="space-y-2">
+          {(deal.client.channels || []).map((c, i) => (
+            <div key={i} className="flex items-center gap-2 p-2 rounded-xl border">
+              <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs bg-gray-100 text-gray-700 border border-gray-200">{c.type}</span>
+              <div className="text-sm text-gray-700 truncate">{c.identifier}</div>
+              <button className="ml-auto text-xs px-2 py-1 rounded-lg border hover:bg-gray-50">Отключить</button>
+            </div>
+          ))}
+        </div>
+        <button className="mt-2 w-full text-sm px-3 py-2 rounded-xl border hover:bg-gray-50">Добавить канал</button>
+      </div>
+      <div className="mt-4">
+        <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Быстрые действия</div>
+        <div className="grid grid-cols-2 gap-2">
+          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Создать заказ</button>
+          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Отправить ссылку</button>
+          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Объединить</button>
+          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Заметка</button>
+        </div>
+      </div>
+      <div className="mt-auto pt-3 text-xs text-gray-500">Подсказка: карточка сделки откроется из центральной доски.</div>
+    </div>
+  );
+}

--- a/site/assets/crm/components/FiltersBar.tsx
+++ b/site/assets/crm/components/FiltersBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+type Filters = { assignee: string | 'all'; channel: string | 'all'; q: string };
+export default function FiltersBar({ value, onChange }: { value: Filters; onChange: (v: Filters) => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="inline-flex rounded-xl border border-gray-200 bg-white p-1">
+        {['all','Мария Савельева','Игорь К.'].map(a => (
+          <button key={a}
+            onClick={() => onChange({ ...value, assignee: a as Filters['assignee'] })}
+            className={`px-3 py-1.5 rounded-lg text-sm transition ${value.assignee === a ? 'bg-gray-900 text-white' : 'hover:bg-gray-100'}`}>
+            {a === 'all' ? 'Все' : a}
+          </button>
+        ))}
+      </div>
+      <div className="inline-flex rounded-xl border border-gray-200 bg-white p-1">
+        {['all','telegram','whatsapp','instagram','email','website_chat'].map(c => (
+          <button key={c}
+            onClick={() => onChange({ ...value, channel: c as Filters['channel'] })}
+            className={`px-3 py-1.5 rounded-lg text-sm transition ${value.channel === c ? 'bg-gray-900 text-white' : 'hover:bg-gray-100'}`}>
+            {c === 'all' ? 'Все каналы' : c}
+          </button>
+        ))}
+      </div>
+      <input
+        value={value.q}
+        onChange={(e) => onChange({ ...value, q: e.target.value })}
+        className="rounded-xl border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        placeholder="Поиск по сделкам"
+      />
+    </div>
+  );
+}

--- a/site/assets/crm/components/PipelineList.tsx
+++ b/site/assets/crm/components/PipelineList.tsx
@@ -1,0 +1,19 @@
+import React, { useEffect, useState } from 'react';
+type Pipeline = { id: string; name: string };
+type Props = { activeId: string | null; onSelect: (id: string) => void; };
+
+export default function PipelineList({ activeId, onSelect }: Props) {
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  useEffect(() => { setPipelines([]); }, []);
+  return (
+    <div className="space-y-2">
+      {pipelines.map((p) => (
+        <button key={p.id} onClick={() => onSelect(p.id)}
+          className={`w-full text-left px-3 py-2 rounded-xl border transition ${
+            p.id === activeId ? 'bg-white border-black' : 'bg-white/60 border-transparent hover:border-gray-300'}`}>
+          <div className="font-semibold">{p.name}</div>
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add CrmLayout shell combining pipeline list, filters, deal board, and profile panes
- introduce placeholder components for pipelines, stages, deals, and filters managed via local state only

## Testing
- not run (UI skeleton only)


------
https://chatgpt.com/codex/tasks/task_e_68cee42ebe0883239483912f0a63b831