### PR TITLE
Add CRM React entry point

### DIFF
--- a/site/assets/crm/index.tsx
+++ b/site/assets/crm/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import CrmLayout from './components/CrmLayout';
+import '../styles/app.css';
+
+const mount = () => {
+  const el = document.getElementById('crm-root');
+  if (!el) return;
+  const root = createRoot(el);
+  root.render(<CrmLayout />);
+};
+
+document.addEventListener('turbo:load', mount);
+if (document.readyState === 'complete' || document.readyState === 'interactive') {
+  setTimeout(mount, 0);
+}


### PR DESCRIPTION
## Summary
- add a placeholder React entry point for the CRM area that mounts `CrmLayout` when the CRM root element is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee4ed45188323986483e0cfa82a2c