### PR TITLE
Add CRM webpack entry

### DIFF
--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -23,6 +23,7 @@ Encore
      */
     .addEntry('app', './assets/app.js')
     .addEntry('chatCenter', './assets/chat-center/index.tsx')
+    .addEntry('crm', './assets/crm/index.tsx')
 
 
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)


### PR DESCRIPTION
## Summary
- register the CRM frontend entry point in the webpack configuration next to chatCenter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cee591a85083239dcb13fb45fd893a