### PR TITLE
Add CRM stages route and template

### DIFF
--- a/site/src/Controller/CrmController.php
+++ b/site/src/Controller/CrmController.php
@@ -6,11 +6,17 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class CrmController extends AbstractController
+final class CrmController extends AbstractController
 {
-    #[Route('/crm', name: 'crm.index', methods: ['GET'])]
+    #[Route('/crm', name: 'crm_index', methods: ['GET'])]
     public function index(): Response
     {
         return $this->render('crm/index.html.twig');
+    }
+
+    #[Route('/crm/pipelines/{id}/stages', name: 'crm_stages', methods: ['GET'])]
+    public function stages(string $id): Response
+    {
+        return $this->render('crm/stages.html.twig', ['pipelineId' => $id]);
     }
 }

--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -35,9 +35,9 @@
                         💬 Чат-центр
                     </a>
 
-                    <a href="{{ path('crm.index') }}"
+                    <a href="{{ path('crm_index') }}"
                        class="block px-3 py-2 rounded hover:bg-gray-800
-                              {{ app.request.attributes.get('_route') starts with 'crm.' ? 'bg-gray-800' : '' }}">
+                              {{ app.request.attributes.get('_route') starts with 'crm_' ? 'bg-gray-800' : '' }}">
                         📊 CRM
                     </a>
 

--- a/site/templates/crm/stages.html.twig
+++ b/site/templates/crm/stages.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}CRM — Редактор этапов{% endblock %}
+
+{% block body %}
+  <div id="crm-stages-root" data-pipeline-id="{{ pipelineId }}"></div>
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+  {{ encore_entry_script_tags('crm') }}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a crm_stages controller action to render the stages editor
- create the stages template with the pipeline id container
- update the CRM navigation link to use the crm_index route name

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf98f227dc8323a6e9d80d8f642833