### PR TITLE
Conditionally mount CRM stages editor

### DIFF
--- a/site/assets/crm/index.tsx
+++ b/site/assets/crm/index.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import CrmLayout from './components/CrmLayout';
+import StagesEditor from './components/StagesEditor';
 import '../styles/app.css';
 
 const mount = () => {
+  const stagesEl = document.getElementById('crm-stages-root');
+  if (stagesEl) {
+    const pipelineId = stagesEl.getAttribute('data-pipeline-id') as string;
+    const root = createRoot(stagesEl);
+    root.render(<StagesEditor pipelineId={pipelineId} />);
+    return;
+  }
+
   const el = document.getElementById('crm-root');
-  if (!el) return;
-  const root = createRoot(el);
-  root.render(<CrmLayout />);
+  if (el) {
+    const root = createRoot(el);
+    root.render(<CrmLayout />);
+  }
 };
 
 document.addEventListener('turbo:load', mount);


### PR DESCRIPTION
## Summary
- mount the StagesEditor when the dedicated stages root is present
- keep the existing CRM layout mount as the fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf9b17a0948323938c93d6160dee2c