### PR TITLE
Fix Doctrine migration comment quoting

### DIFF
--- a/site/migrations/Version20250830130000.php
+++ b/site/migrations/Version20250830130000.php
@@ -19,7 +19,7 @@ final class Version20250830130000 extends AbstractMigration
         $this->addSql('ALTER TABLE "crm_deals" ADD COLUMN stage_entered_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT NOW()');
         $this->addSql('UPDATE "crm_deals" SET stage_entered_at = opened_at');
         $this->addSql('ALTER TABLE "crm_deals" ALTER COLUMN stage_entered_at DROP DEFAULT');
-        $this->addSql('COMMENT ON COLUMN "crm_deals".stage_entered_at IS ''(DC2Type:datetime_immutable)''');
+        $this->addSql("COMMENT ON COLUMN \"crm_deals\".stage_entered_at IS '(DC2Type:datetime_immutable)'");
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
## Summary
- escape the Doctrine column comment string using a PHP-safe quoting style

## Testing
- php -l migrations/Version20250830130000.php

------
https://chatgpt.com/codex/tasks/task_e_68cf9c77cd04832386420c1c8720aba8