### PR TITLE
Move company switcher to sidebar

### DIFF
--- a/site/templates/base.html.twig
+++ b/site/templates/base.html.twig
@@ -22,6 +22,11 @@
             </div>
             <nav class="flex-1 px-4 py-6 space-y-6 text-sm">
 
+                <!-- Выбор компании -->
+                <div>
+                    {{ render(controller('App\\Controller\\CompanySwitchController::widget')) }}
+                </div>
+
                 <!-- Рабочая зона -->
                 <div>
                     <h3 class="text-xs uppercase tracking-wider text-gray-400 mb-2">Рабочая зона</h3>
@@ -138,9 +143,6 @@
 
         <!-- Main content -->
         <main class="flex-1 p-8 overflow-auto">
-            <div class="mb-4 flex justify-end">
-                {{ render(controller('App\\Controller\\CompanySwitchController::widget')) }}
-            </div>
             {% set flashTypes = ['success', 'warning', 'danger', 'info'] %}
             {% set flashClasses = {
                 'success': 'border-green-400 bg-green-100 text-green-700',


### PR DESCRIPTION
## Summary
- place the company switch widget at the top of the sidebar above the "Рабочая зона" navigation section
- remove the redundant widget container from the main content area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfa22d8b1c8323b36c0997dd763583