### PR TITLE
Revert company switch widget styling

### DIFF
--- a/site/templates/company_switch/widget.html.twig
+++ b/site/templates/company_switch/widget.html.twig
@@ -1,18 +1,9 @@
 {% set activeId = activeCompany ? activeCompany.id : null %}
-<div class="space-y-2 text-sm text-gray-200">
-    <label for="company-switcher" class="block text-xs font-semibold uppercase tracking-wider text-gray-400">Компания</label>
-    <div class="relative">
-        <select
-            id="company-switcher"
-            class="w-full appearance-none rounded-md border border-gray-700 bg-gray-800 px-3 py-2 pr-10 text-sm text-white shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
-            onchange="if(this.value) window.location.href=this.value;"
-        >
-            {% for uc in companies %}
-                <option value="{{ path('company.switch', {id: uc.company.id}) }}" {% if activeId == uc.company.id %}selected{% endif %}>{{ uc.company.name }}</option>
-            {% endfor %}
-        </select>
-        <svg class="pointer-events-none absolute inset-y-0 right-3 my-auto h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-        </svg>
-    </div>
+<div class="text-sm">
+    <label for="company-switcher" class="mr-2">Компания:</label>
+    <select id="company-switcher" class="border rounded px-2 py-1 bg-white" onchange="if(this.value) window.location.href=this.value;">
+        {% for uc in companies %}
+            <option value="{{ path('company.switch', {id: uc.company.id}) }}" {% if activeId == uc.company.id %}selected{% endif %}>{{ uc.company.name }}</option>
+        {% endfor %}
+    </select>
 </div>


### PR DESCRIPTION
## Summary
- restore the previous layout for the company switcher dropdown by reverting the recent styling changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfa908638883238c03f0b8d8922406