### PR TITLE
Implement CRM deal board data loading and drag-drop

### DIFF
--- a/site/assets/crm/components/DealBoard.tsx
+++ b/site/assets/crm/components/DealBoard.tsx
@@ -1,22 +1,252 @@
+import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+
+type Stage = {
+  id: string;
+  name: string;
+  position: number;
+  color?: string;
+  probability?: number;
+  isStart?: boolean;
+  isWon?: boolean;
+  isLost?: boolean;
+  slaHours?: number | null;
+};
+
+type Deal = {
+  id: string;
+  title: string;
+  stage: Stage;
+  pipeline: { id: string; name: string };
+  client?: { id: string | number; name?: string; displayName?: string; firstName?: string; lastName?: string; channels?: Array<{ type: string; identifier: string }> } | null;
+  [key: string]: any;
+};
+
+type PipelineDetailed = {
+  id: string;
+  name: string;
+  stages: Stage[];
+};
+
+type DealsResponse = {
+  items: Deal[];
+  total: number;
+  limit: number;
+  offset: number;
+};
+
 type Props = {
   pipelineId: string | null;
   filters: { assignee: string | 'all'; channel: string | 'all'; q: string };
   onOpenDeal: (deal: any) => void;
 };
+
+type DragPayload = { dealId: string; fromStageId: string };
+
 export default function DealBoard({ pipelineId, filters, onOpenDeal }: Props) {
-  const [stages, setStages] = useState<Array<{ id: string; name: string; wip?: number }>>([]);
-  const [dealsByStage, setDealsByStage] = useState<Record<string, any[]>>({});
-  useEffect(() => { setStages([]); setDealsByStage({}); }, [pipelineId, filters]);
+  const [stages, setStages] = useState<Stage[]>([]);
+  const [dealsByStage, setDealsByStage] = useState<Record<string, Deal[]>>({});
+  const [draggedDeal, setDraggedDeal] = useState<DragPayload | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!pipelineId) {
+      setStages([]);
+      setDealsByStage({});
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setStages([]);
+    setDealsByStage({});
+
+    (async () => {
+      try {
+        const { data } = await axios.get<PipelineDetailed>(`/api/crm/pipelines/${pipelineId}`);
+        if (cancelled) return;
+
+        const sorted = [...(data.stages || [])].sort((a, b) => a.position - b.position);
+        setStages(sorted);
+      } catch {
+        if (!cancelled) {
+          setStages([]);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pipelineId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!pipelineId) {
+      setDealsByStage({});
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const params: Record<string, string | number | undefined> = {
+      pipeline: pipelineId,
+      limit: 100,
+      offset: 0,
+    };
+
+    if (filters.assignee !== 'all') {
+      params.owner = filters.assignee;
+    }
+
+    const trimmedSearch = filters.q.trim();
+    if (trimmedSearch !== '') {
+      params.search = trimmedSearch;
+    }
+
+    axios
+      .get<DealsResponse>('/api/crm/deals', { params })
+      .then(({ data }) => {
+        if (cancelled) return;
+
+        const grouped: Record<string, Deal[]> = {};
+        data.items.forEach((deal) => {
+          const stageId = deal.stage?.id;
+          if (!stageId) return;
+          if (!grouped[stageId]) {
+            grouped[stageId] = [];
+          }
+          grouped[stageId].push(deal);
+        });
+
+        setDealsByStage(grouped);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDealsByStage({});
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pipelineId, filters.assignee, filters.channel, filters.q]);
+
+  if (!pipelineId) {
+    return <div className="h-full flex items-center justify-center text-sm text-gray-500">Выберите воронку</div>;
+  }
+
+  const handleDragStart = (event: React.DragEvent<HTMLButtonElement>, stageId: string, deal: Deal) => {
+    const payload: DragPayload = { dealId: deal.id, fromStageId: stageId };
+    event.dataTransfer.effectAllowed = 'move';
+    try {
+      event.dataTransfer.setData('application/json', JSON.stringify(payload));
+    } catch {
+      // ignore unsupported DataTransfer operations
+    }
+    setDraggedDeal(payload);
+  };
+
+  const handleDragEnd = () => {
+    setDraggedDeal(null);
+  };
+
+  const handleDrop = async (event: React.DragEvent<HTMLDivElement>, targetStageId: string) => {
+    event.preventDefault();
+
+    let payload = draggedDeal;
+    if (!payload) {
+      try {
+        const raw = event.dataTransfer.getData('application/json');
+        if (raw) {
+          payload = JSON.parse(raw) as DragPayload;
+        }
+      } catch {
+        payload = null;
+      }
+    }
+
+    if (!payload) return;
+
+    const { dealId, fromStageId } = payload;
+    if (fromStageId === targetStageId) {
+      setDraggedDeal(null);
+      return;
+    }
+
+    const sourceList = dealsByStage[fromStageId] || [];
+    const deal = sourceList.find((item) => item.id === dealId);
+    if (!deal) {
+      setDraggedDeal(null);
+      return;
+    }
+
+    const snapshot: Record<string, Deal[]> = {};
+    const stageIds = new Set<string>([...Object.keys(dealsByStage), ...stages.map((stage) => stage.id)]);
+    stageIds.forEach((id) => {
+      snapshot[id] = [...(dealsByStage[id] || [])];
+    });
+
+    const targetStage = stages.find((stage) => stage.id === targetStageId);
+    const optimisticDeal: Deal = {
+      ...deal,
+      stage: targetStage ? { ...deal.stage, ...targetStage } : { ...deal.stage, id: targetStageId },
+    };
+
+    setDealsByStage((prev) => {
+      const next = { ...prev };
+      next[fromStageId] = (prev[fromStageId] || []).filter((item) => item.id !== dealId);
+      next[targetStageId] = [optimisticDeal, ...(prev[targetStageId] || [])];
+      return next;
+    });
+
+    try {
+      const { data } = await axios.post<Deal & { stageHistory?: unknown[] }>(`/api/crm/deals/${dealId}/move`, {
+        toStageId: targetStageId,
+      });
+
+      setDealsByStage((prev) => {
+        const next = { ...prev };
+        next[targetStageId] = (prev[targetStageId] || []).map((item) => (item.id === dealId ? data : item));
+        return next;
+      });
+    } catch {
+      setDealsByStage(snapshot);
+    } finally {
+      setDraggedDeal(null);
+    }
+  };
+
+  const allowDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+  };
+
   return (
     <div className="grid grid-cols-3 gap-3">
-      {stages.map((s) => (
-        <div key={s.id} className="flex flex-col rounded-2xl border bg-white">
-          <div className="p-3 border-b"><div className="font-semibold">{s.name}</div></div>
-          <div className="p-3 space-y-2">
-            {(dealsByStage[s.id] || []).map((d) => (
-              <button key={d.id} onClick={() => onOpenDeal(d)} className="rounded-2xl border bg-white p-3 shadow-sm text-left">
-                <div className="font-semibold">{d.title}</div>
+      {stages.map((stage) => (
+        <div
+          key={stage.id}
+          className="flex flex-col rounded-2xl border bg-white"
+          onDragOver={allowDrop}
+          onDrop={(event) => handleDrop(event, stage.id)}
+        >
+          <div className="p-3 border-b">
+            <div className="font-semibold">{stage.name}</div>
+          </div>
+          <div className="p-3 space-y-2 min-h-[1rem]">
+            {(dealsByStage[stage.id] || []).map((deal) => (
+              <button
+                key={deal.id}
+                type="button"
+                draggable
+                onDragStart={(event) => handleDragStart(event, stage.id, deal)}
+                onDragEnd={handleDragEnd}
+                onClick={() => onOpenDeal(deal)}
+                className="w-full rounded-2xl border bg-white p-3 shadow-sm text-left"
+              >
+                <div className="font-semibold">{deal.title}</div>
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- load pipeline stages and deals for the selected CRM pipeline and render columns based on server data
- support dragging deals between stages with optimistic updates and rollback on failure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfba4bd0d08323b1cbdcdb444e7dc9