### PR TITLE
feat: align CRM Tailwind styling

### DIFF
--- a/site/assets/crm/components/CrmLayout.tsx
+++ b/site/assets/crm/components/CrmLayout.tsx
@@ -20,22 +20,22 @@ export default function CrmLayout() {
 
   return (
     <div className="h-full grid grid-cols-12 gap-4">
-      <aside className="col-span-2 bg-white rounded-2xl border p-3">
+      <aside className="col-span-2 rounded-2xl border border-gray-200 bg-white px-3 py-2">
         <div className="flex items-center gap-2 mb-3"><div className="text-lg font-semibold">Воронки</div></div>
         <PipelineList activeId={activePipelineId} onSelect={setActivePipelineId} />
       </aside>
 
-      <main className="col-span-7 bg-white rounded-2xl border flex flex-col">
-        <div className="p-3 border-b flex items-center gap-3">
+      <main className="col-span-7 rounded-2xl border border-gray-200 bg-white px-3 py-2 flex flex-col">
+        <div className="flex items-center gap-3 border-b border-gray-200 pb-2 mb-2">
           <FiltersBar value={filters} onChange={setFilters} />
-          <button className="ml-auto px-3 py-2 rounded-xl border hover:bg-gray-50">Новая сделка</button>
+          <button className="ml-auto px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Новая сделка</button>
         </div>
-        <div className="flex-1 p-3 overflow-auto">
+        <div className="flex-1 overflow-auto pt-2">
           <DealBoard pipelineId={activePipelineId} filters={filters} onOpenDeal={setActiveDeal} />
         </div>
       </main>
 
-      <aside className="col-span-3 bg-white rounded-2xl border p-3">
+      <aside className="col-span-3 rounded-2xl border border-gray-200 bg-white px-3 py-2">
         <DealProfile deal={activeDeal} />
       </aside>
     </div>

--- a/site/assets/crm/components/DealBoard.tsx
+++ b/site/assets/crm/components/DealBoard.tsx
@@ -229,14 +229,14 @@ export default function DealBoard({ pipelineId, filters, onOpenDeal }: Props) {
       {stages.map((stage) => (
         <div
           key={stage.id}
-          className="flex flex-col rounded-2xl border bg-white"
+          className="flex flex-col rounded-2xl border border-gray-200 bg-white px-3 py-2"
           onDragOver={allowDrop}
           onDrop={(event) => handleDrop(event, stage.id)}
         >
-          <div className="p-3 border-b">
+          <div className="border-b border-gray-200 pb-2 mb-2">
             <div className="font-semibold">{stage.name}</div>
           </div>
-          <div className="p-3 space-y-2 min-h-[1rem]">
+          <div className="space-y-2 min-h-[1rem]">
             {(dealsByStage[stage.id] || []).map((deal) => {
               const slaHours = stage.slaHours;
               let isSlaOverdue = false;
@@ -254,7 +254,7 @@ export default function DealBoard({ pipelineId, filters, onOpenDeal }: Props) {
               }
 
               const className = [
-                'w-full rounded-2xl border bg-white p-3 shadow-sm text-left relative',
+                'w-full rounded-2xl border border-gray-200 bg-white px-3 py-2 shadow-sm text-left relative',
                 isSlaOverdue ? 'ring-1 ring-rose-300' : '',
               ]
                 .filter(Boolean)

--- a/site/assets/crm/components/DealProfile.tsx
+++ b/site/assets/crm/components/DealProfile.tsx
@@ -25,22 +25,22 @@ export default function DealProfile({ deal }: { deal: Deal | null }) {
         <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Каналы</div>
         <div className="space-y-2">
           {(deal.client.channels || []).map((c, i) => (
-            <div key={i} className="flex items-center gap-2 p-2 rounded-xl border">
+            <div key={i} className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
               <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs bg-gray-100 text-gray-700 border border-gray-200">{c.type}</span>
               <div className="text-sm text-gray-700 truncate">{c.identifier}</div>
-              <button className="ml-auto text-xs px-2 py-1 rounded-lg border hover:bg-gray-50">Отключить</button>
+              <button className="ml-auto text-xs px-2 py-1 rounded-lg border border-gray-300 hover:bg-gray-50">Отключить</button>
             </div>
           ))}
         </div>
-        <button className="mt-2 w-full text-sm px-3 py-2 rounded-xl border hover:bg-gray-50">Добавить канал</button>
+        <button className="mt-2 w-full text-sm px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Добавить канал</button>
       </div>
       <div className="mt-4">
         <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Быстрые действия</div>
         <div className="grid grid-cols-2 gap-2">
-          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Создать заказ</button>
-          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Отправить ссылку</button>
-          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Объединить</button>
-          <button className="px-3 py-2 rounded-xl border hover:bg-gray-50">Заметка</button>
+          <button className="px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Создать заказ</button>
+          <button className="px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Отправить ссылку</button>
+          <button className="px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Объединить</button>
+          <button className="px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Заметка</button>
         </div>
       </div>
       <div className="mt-auto pt-3 text-xs text-gray-500">Подсказка: карточка сделки откроется из центральной доски.</div>

--- a/site/assets/crm/components/FiltersBar.tsx
+++ b/site/assets/crm/components/FiltersBar.tsx
@@ -3,7 +3,7 @@ type Filters = { assignee: string | 'all'; channel: string | 'all'; q: string };
 export default function FiltersBar({ value, onChange }: { value: Filters; onChange: (v: Filters) => void }) {
   return (
     <div className="flex items-center gap-2">
-      <div className="inline-flex rounded-xl border border-gray-200 bg-white p-1">
+      <div className="inline-flex rounded-2xl border border-gray-200 bg-white p-1">
         {['all','Мария Савельева','Игорь К.'].map(a => (
           <button key={a}
             onClick={() => onChange({ ...value, assignee: a as Filters['assignee'] })}
@@ -12,7 +12,7 @@ export default function FiltersBar({ value, onChange }: { value: Filters; onChan
           </button>
         ))}
       </div>
-      <div className="inline-flex rounded-xl border border-gray-200 bg-white p-1">
+      <div className="inline-flex rounded-2xl border border-gray-200 bg-white p-1">
         {['all','telegram','whatsapp','instagram','email','website_chat'].map(c => (
           <button key={c}
             onClick={() => onChange({ ...value, channel: c as Filters['channel'] })}
@@ -24,7 +24,7 @@ export default function FiltersBar({ value, onChange }: { value: Filters; onChan
       <input
         value={value.q}
         onChange={(e) => onChange({ ...value, q: e.target.value })}
-        className="rounded-xl border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+        className="w-full max-w-xs px-3 py-2 rounded-xl border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
         placeholder="Поиск по сделкам"
       />
     </div>

--- a/site/assets/crm/components/PipelineList.tsx
+++ b/site/assets/crm/components/PipelineList.tsx
@@ -30,12 +30,19 @@ export default function PipelineList({ activeId, onSelect }: Props) {
 
   return (
     <div className="space-y-2">
-      <button onClick={createPipeline} className="w-full px-3 py-2 rounded-xl border bg-white hover:bg-gray-50">
+      <button onClick={createPipeline} className="w-full px-3 py-2 rounded-2xl border border-gray-300 bg-white hover:bg-gray-50">
         + Добавить воронку
       </button>
 
       {pipelines.map((p) => (
-        <div key={p.id} className={`px-3 py-2 rounded-xl border ${p.id === activeId ? 'bg-white border-black' : 'bg-white/60 border-transparent hover:border-gray-300'}`}>
+        <div
+          key={p.id}
+          className={`rounded-2xl border px-3 py-2 transition ${
+            p.id === activeId
+              ? 'border-gray-900 bg-white shadow-sm'
+              : 'border-gray-200 bg-white hover:border-gray-300'
+          }`}
+        >
           <div className="flex items-center justify-between">
             <button onClick={() => onSelect(p.id)} className="font-semibold text-left">{p.name}</button>
             <a href={`/crm/pipelines/${p.id}/stages`} className="text-sm text-blue-600 hover:underline">Редактировать этапы</a>

--- a/site/assets/crm/components/StagesEditor.tsx
+++ b/site/assets/crm/components/StagesEditor.tsx
@@ -167,7 +167,7 @@ export default function StagesEditor({ pipelineId }: { pipelineId: UUID }) {
       });
     };
     return (
-      <form onSubmit={submit} className="rounded-2xl border border-gray-200 bg-white p-4 space-y-3">
+      <form onSubmit={submit} className="rounded-2xl border border-gray-200 bg-white px-3 py-2 space-y-3">
         <div className="flex items-center justify-between">
           <h4 className="font-semibold text-gray-900">{initial?.id ? 'Редактировать этап' : 'Добавить этап'}</h4>
           <button type="button" onClick={onCancel} className="text-gray-500 hover:text-gray-700">×</button>
@@ -252,7 +252,7 @@ export default function StagesEditor({ pipelineId }: { pipelineId: UUID }) {
           {stages.map(s => (
             <div
               key={s.id}
-              className="group rounded-2xl shadow p-4 bg-white border border-gray-200 w-80 select-none"
+              className="group rounded-2xl border border-gray-200 bg-white px-3 py-2 shadow w-80 select-none"
               draggable
               onDragStart={(e) => onDragStart(e, s.id)}
               onDragOver={onDragOver}
@@ -271,7 +271,7 @@ export default function StagesEditor({ pipelineId }: { pipelineId: UUID }) {
               <div className="flex items-center justify-between text-sm text-gray-500">
                 <span>Позиция: {s.position}</span>
                 <div className="flex gap-2">
-                  <button className="px-3 py-1.5 rounded-xl border hover:bg-gray-50" onClick={() => setEditStage(s)}>Ред.</button>
+                  <button className="px-3 py-1.5 rounded-xl border border-gray-300 hover:bg-gray-50" onClick={() => setEditStage(s)}>Ред.</button>
                   <button className="px-3 py-1.5 rounded-xl border border-rose-300 text-rose-700 hover:bg-rose-50" onClick={() => deleteStage(s.id)}>Удалить</button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- align CRM layout containers and board cards with the shared rounded-2xl white panel style
- refresh pipeline list, deal profile actions, and filters to reuse the CRM form/border styling
- streamline the stages editor panels to match the gray palette and form field appearance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbd944be88323b3492cef5b274390