### PR TITLE
Add CRM deal creation modal

### DIFF
--- a/site/assets/crm/components/CrmLayout.tsx
+++ b/site/assets/crm/components/CrmLayout.tsx
@@ -1,43 +1,88 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import PipelineList from './PipelineList';
 import FiltersBar from './FiltersBar';
 import DealBoard from './DealBoard';
 import DealProfile from './DealProfile';
+import DealCreateModal from './DealCreateModal';
 
 export type Deal = {
-  id: string; title: string; value?: number;
-  client: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> };
-  channelType?: string; unread?: number; assignee?: string;
-  pipelineId: string; stageId: string; updatedAt?: number; daysInStage?: number;
+  id: string;
+  title: string;
+  value?: number;
+  amount?: number | null;
+  client?: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> } | null;
+  channelType?: string;
+  unread?: number;
+  assignee?: string;
+  pipelineId?: string;
+  stageId?: string;
+  updatedAt?: number;
+  daysInStage?: number;
+  stage?: { id: string; name: string };
+  pipeline?: { id: string; name: string };
+  stageEnteredAt?: string;
 };
 
+type PipelineSummary = { id: string; name: string };
+
 export default function CrmLayout() {
-  const [activePipelineId, setActivePipelineId] = useState<string | null>(null);
+  const [activePipeline, setActivePipeline] = useState<PipelineSummary | null>(null);
   const [activeDeal, setActiveDeal] = useState<Deal | null>(null);
   const [filters, setFilters] = useState<{ assignee: string | 'all'; channel: string | 'all'; q: string }>({
     assignee: 'all', channel: 'all', q: ''
   });
+  const [isCreateModalOpen, setCreateModalOpen] = useState(false);
+  const [boardReloadKey, setBoardReloadKey] = useState(0);
+
+  const activePipelineId = activePipeline?.id ?? null;
+
+  const handleSelectPipeline = useCallback((pipeline: PipelineSummary) => {
+    setActivePipeline(pipeline);
+    setActiveDeal(null);
+  }, []);
+
+  const handleDealCreated = useCallback((deal: Deal) => {
+    setCreateModalOpen(false);
+    setBoardReloadKey((prev) => prev + 1);
+    setActiveDeal(deal);
+  }, []);
+
+  const canCreateDeal = Boolean(activePipelineId);
 
   return (
     <div className="h-full grid grid-cols-12 gap-4">
       <aside className="col-span-2 rounded-2xl border border-gray-200 bg-white px-3 py-2">
         <div className="flex items-center gap-2 mb-3"><div className="text-lg font-semibold">Воронки</div></div>
-        <PipelineList activeId={activePipelineId} onSelect={setActivePipelineId} />
+        <PipelineList activeId={activePipelineId} onSelect={handleSelectPipeline} />
       </aside>
 
       <main className="col-span-7 rounded-2xl border border-gray-200 bg-white px-3 py-2 flex flex-col">
         <div className="flex items-center gap-3 border-b border-gray-200 pb-2 mb-2">
           <FiltersBar value={filters} onChange={setFilters} />
-          <button className="ml-auto px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Новая сделка</button>
+          <button
+            type="button"
+            onClick={() => setCreateModalOpen(true)}
+            disabled={!canCreateDeal}
+            className={`ml-auto px-3 py-2 rounded-xl transition font-semibold ${canCreateDeal ? 'bg-black text-white hover:bg-black/90' : 'bg-gray-100 text-gray-400 cursor-not-allowed'}`}
+          >
+            Новая сделка
+          </button>
         </div>
         <div className="flex-1 overflow-auto pt-2">
-          <DealBoard pipelineId={activePipelineId} filters={filters} onOpenDeal={setActiveDeal} />
+          <DealBoard pipelineId={activePipelineId} filters={filters} onOpenDeal={(deal) => setActiveDeal(deal)} reloadKey={boardReloadKey} />
         </div>
       </main>
 
       <aside className="col-span-3 rounded-2xl border border-gray-200 bg-white px-3 py-2">
         <DealProfile deal={activeDeal} />
       </aside>
+
+      <DealCreateModal
+        open={isCreateModalOpen}
+        pipeline={activePipeline}
+        onClose={() => setCreateModalOpen(false)}
+        onCreated={handleDealCreated}
+      />
     </div>
   );
 }

--- a/site/assets/crm/components/DealCreateModal.tsx
+++ b/site/assets/crm/components/DealCreateModal.tsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+type PipelineSummary = { id: string; name: string };
+
+type Props = {
+  open: boolean;
+  pipeline: PipelineSummary | null;
+  onClose: () => void;
+  onCreated: (deal: any) => void;
+};
+
+export default function DealCreateModal({ open, pipeline, onClose, onCreated }: Props) {
+  const [title, setTitle] = useState('');
+  const [amount, setAmount] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle('');
+    setAmount('');
+    setClientId('');
+    setError(null);
+    setSaving(false);
+  }, [open, pipeline?.id]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (!saving) {
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose, saving]);
+
+  if (!open) {
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!pipeline) {
+      setError('Выберите воронку для создания сделки');
+      return;
+    }
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setError('Укажите название сделки');
+      return;
+    }
+
+    const payload: Record<string, string> = {
+      pipelineId: pipeline.id,
+      title: trimmedTitle,
+    };
+    if (amount.trim() !== '') {
+      payload.amount = amount.trim();
+    }
+    if (clientId.trim() !== '') {
+      payload.clientId = clientId.trim();
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const { data } = await axios.post('/api/crm/deals', payload);
+      setSaving(false);
+      onCreated(data);
+    } catch (err: any) {
+      setSaving(false);
+      setError(err?.response?.data?.error || 'Не удалось создать сделку');
+    }
+  };
+
+  const handleBackdropClick = () => {
+    if (!saving) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" onClick={handleBackdropClick} />
+      <div className="relative z-10 w-full max-w-lg rounded-3xl bg-white p-6 shadow-xl">
+        <div className="mb-4">
+          <div className="text-lg font-semibold">Новая сделка</div>
+          <div className="mt-1 text-sm text-gray-500">
+            {pipeline ? `Создание в воронке «${pipeline.name}»` : 'Выберите воронку, чтобы продолжить'}
+          </div>
+        </div>
+        {error && (
+          <div className="mb-3 rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+            {error}
+          </div>
+        )}
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">Название сделки</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Введите название"
+              className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+              autoFocus
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">Сумма, ₽</label>
+              <input
+                type="text"
+                value={amount}
+                onChange={(event) => setAmount(event.target.value)}
+                placeholder="Необязательно"
+                className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">ID клиента</label>
+              <input
+                type="text"
+                value={clientId}
+                onChange={(event) => setClientId(event.target.value)}
+                placeholder="Необязательно"
+                className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none focus:ring-1 focus:ring-black"
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={handleBackdropClick}
+              className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800"
+            >
+              Отмена
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !pipeline}
+              className={`rounded-xl px-4 py-2 text-sm font-semibold text-white transition ${saving || !pipeline ? 'bg-gray-300 cursor-not-allowed' : 'bg-black hover:bg-black/90'}`}
+            >
+              {saving ? 'Создание…' : 'Создать'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/site/assets/crm/components/DealProfile.tsx
+++ b/site/assets/crm/components/DealProfile.tsx
@@ -1,36 +1,57 @@
 import React from 'react';
+
 type Deal = {
-  id: string; title: string; value?: number;
-  client: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> };
-  unread?: number; daysInStage?: number;
+  id: string;
+  title: string;
+  value?: number | null;
+  amount?: number | string | null;
+  client?: { id: number; name: string; channels?: Array<{ type: string; identifier: string }> } | null;
+  unread?: number;
+  daysInStage?: number;
 };
+
 export default function DealProfile({ deal }: { deal: Deal | null }) {
-  if (!deal) return <div className="h-full flex items-center justify-center text-sm text-gray-500">Выберите сделку</div>;
+  if (!deal) {
+    return <div className="h-full flex items-center justify-center text-sm text-gray-500">Выберите сделку</div>;
+  }
+
+  const clientName = deal.client?.name ?? 'Клиент не указан';
+  const clientId = deal.client?.id;
+  const initials = (clientName || '').split(' ').map((s) => s[0]).filter(Boolean).slice(0, 2).join('').toUpperCase();
+  const amount = deal.value ?? (typeof deal.amount === 'number' ? deal.amount : null);
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex items-start gap-3">
         <div className="w-12 h-12 rounded-2xl bg-gray-100 flex items-center justify-center font-semibold">
-          {(deal.client.name || '').split(' ').map(s => s[0]).slice(0,2).join('')}
+          {initials || '??'}
         </div>
         <div className="flex-1">
-          <div className="font-semibold leading-tight">{deal.client.name}</div>
-          <div className="text-xs text-gray-500">ID клиента: {deal.client.id}</div>
+          <div className="font-semibold leading-tight">{clientName}</div>
+          <div className="text-xs text-gray-500">
+            {clientId ? `ID клиента: ${clientId}` : 'ID клиента не задан'}
+          </div>
         </div>
         <div className="text-right">
-          <div className="text-sm font-semibold">{deal.value ? `${deal.value} ₽` : ''}</div>
+          <div className="text-sm font-semibold">{amount ? `${amount} ₽` : ''}</div>
           <div className="text-xs text-gray-500">{deal.title}</div>
         </div>
       </div>
       <div className="mt-4">
         <div className="text-xs uppercase tracking-wide text-gray-500 mb-2">Каналы</div>
         <div className="space-y-2">
-          {(deal.client.channels || []).map((c, i) => (
+          {(deal.client?.channels || []).map((c, i) => (
             <div key={i} className="flex items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
               <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs bg-gray-100 text-gray-700 border border-gray-200">{c.type}</span>
               <div className="text-sm text-gray-700 truncate">{c.identifier}</div>
               <button className="ml-auto text-xs px-2 py-1 rounded-lg border border-gray-300 hover:bg-gray-50">Отключить</button>
             </div>
           ))}
+          {(!deal.client || !deal.client.channels || deal.client.channels.length === 0) && (
+            <div className="rounded-xl border border-dashed border-gray-300 px-3 py-2 text-sm text-gray-500">
+              Каналы не подключены
+            </div>
+          )}
         </div>
         <button className="mt-2 w-full text-sm px-3 py-2 rounded-xl border border-gray-300 hover:bg-gray-50">Добавить канал</button>
       </div>

--- a/site/assets/crm/components/PipelineList.tsx
+++ b/site/assets/crm/components/PipelineList.tsx
@@ -3,16 +3,24 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 
 type Pipeline = { id: string; name: string };
-type Props = { activeId: string | null; onSelect: (id: string) => void; };
+type Props = { activeId: string | null; onSelect: (pipeline: Pipeline) => void; };
 
 export default function PipelineList({ activeId, onSelect }: Props) {
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
 
   useEffect(() => {
     axios.get<Pipeline[]>('/api/crm/pipelines')
-      .then(({ data }) => setPipelines(data))
+      .then(({ data }) => {
+        setPipelines(data);
+      })
       .catch(() => setPipelines([]));
   }, []);
+
+  useEffect(() => {
+    if (!activeId && pipelines.length > 0) {
+      onSelect(pipelines[0]);
+    }
+  }, [activeId, pipelines, onSelect]);
 
   const createPipeline = async () => {
     const name = window.prompt('Название воронки');
@@ -20,7 +28,7 @@ export default function PipelineList({ activeId, onSelect }: Props) {
     try {
       const { data } = await axios.post<Pipeline>('/api/crm/pipelines', { name: name.trim() });
       setPipelines(prev => [...prev, data]);
-      onSelect(data.id);
+      onSelect(data);
       if (window.confirm('Перейти к редактору этапов?')) {
         window.location.href = `/crm/pipelines/${data.id}/stages`;
       }
@@ -44,7 +52,7 @@ export default function PipelineList({ activeId, onSelect }: Props) {
           className={`px-3 py-2 rounded-xl border ${p.id === activeId ? 'bg-white border-black' : 'bg-white/60 border-transparent hover:border-gray-300'}`}
         >
           <div className="flex items-center justify-between">
-            <button onClick={() => onSelect(p.id)} className="font-semibold text-left">{p.name}</button>
+            <button onClick={() => onSelect(p)} className="font-semibold text-left">{p.name}</button>
             <a href={`/crm/pipelines/${p.id}/stages`} className="text-sm text-blue-600 hover:underline">
               Редактировать этапы
             </a>


### PR DESCRIPTION
## Summary
- add a CRM modal for creating deals in the active pipeline and enable the toolbar button
- reload the board after new deals, apply filters to loading, and pick the first pipeline automatically
- harden the deal profile rendering when client data is missing

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cfe6f2e670832385cf0f0a5237ff08